### PR TITLE
fix the overflow problem caused by grid

### DIFF
--- a/app/[lng]/about/page.tsx
+++ b/app/[lng]/about/page.tsx
@@ -10,10 +10,10 @@ export default async function Home({ params }: { params: Promise<{ lng: string }
     const source = fs.readFileSync("app/md/about.mdx").toString("utf-8");
 
     return (
-        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen grid grid-rows-[theme(spacing.16)_1fr_theme(spacing.14)]">
+        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen flex flex-col">
             <PageHeader lng={lng} />
-            <main className="flex p-10 pl-20">
-                <div>
+            <main className="flex p-10 pl-20 flex-1 overflow-y-auto">
+                <div className="w-full">
                     <Mdx source={source} />
                 </div>
             </main>

--- a/app/[lng]/games/page.tsx
+++ b/app/[lng]/games/page.tsx
@@ -10,10 +10,14 @@ export default async function Games({ params }: { params: Promise<{ lng: string 
     const { t } = await useTranslation(lng);
 
     return (
-        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen grid grid-rows-[theme(spacing.16)_1fr_theme(spacing.14)]">
+        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen flex flex-col">
             <PageHeader lng={ lng }/>
-            <main className="flex items-center justify-center p-10">
-                Games page..
+            <main className="flex p-10 flex-1 overflow-y-auto">
+                <div className="bg-red-200 w-full h-80 overflow-x-auto">
+                    <div className="bg-blue-200 w-[800px] h-20">
+
+                    </div>
+                </div>
             </main>
             <A1Footer/>
         </div>

--- a/app/[lng]/page.tsx
+++ b/app/[lng]/page.tsx
@@ -13,9 +13,9 @@ export default async function Home({ params }: { params: Promise<{ lng: string }
     const { t } = await useTranslation(lng);
 
     return (
-        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen grid grid-rows-[theme(spacing.16)_1fr_theme(spacing.14)]">
+        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen flex flex-col">
             <PageHeader lng={ lng }/>
-            <main className="flex items-center justify-center p-10">
+            <main className="flex items-center justify-center p-10 flex-1 overflow-y-auto">
                 <A1Anime />
             </main>
             <A1Footer/>

--- a/app/[lng]/teams/page.tsx
+++ b/app/[lng]/teams/page.tsx
@@ -9,9 +9,9 @@ export default async function Teams({ params }: { params: Promise<{ lng: string 
     const { t } = await useTranslation(lng);
 
     return (
-        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen grid grid-rows-[theme(spacing.16)_1fr_theme(spacing.14)]">
+        <div className="p-0 font-[family-name:var(--font-geist-sans)] h-screen flex flex-col">
             <PageHeader lng={ lng }/>
-            <main className="flex items-center justify-center p-10">
+            <main className="flex items-center justify-center p-10 flex-1 overflow-y-auto">
                 Teasm page..
             </main>
             <A1Footer/>


### PR DESCRIPTION
奇怪了 原来父布局用 grid 会导致 子布局里的 overflow 全部显示在父布局，不懂
设计的 classname
grid grid-rows-[theme(spacing.16)_1fr_theme(spacing.14)]