### PR TITLE
🚧 fix: 创建战队或加入战队后立刻获取最新的gameInfo

### DIFF
--- a/clientapp/components/modules/game/GameTeamStatusCard.tsx
+++ b/clientapp/components/modules/game/GameTeamStatusCard.tsx
@@ -12,7 +12,7 @@ export default function GameTeamStatusCard(
     { gameID } : { gameID: number }
 ) {
 
-    const { gameInfo, teamStatus, isLoading } = useGame(gameID)
+    const { gameInfo, teamStatus, isLoading, mutateGameInfo } = useGame(gameID)
 
     const teamStatusElement = {
         "Pending": (
@@ -39,18 +39,14 @@ export default function GameTeamStatusCard(
                 </div>
                 <div className="flex gap-4 pointer-events-auto">
                     <CreateTeamDialog callback={() => {
-                        // setTimeout(() => {
-                        //     fetchGameInfoWithTeamInfo()
-                        // }, 600)
+                        mutateGameInfo()
                     }} gameID={gameInfo?.game_id ?? 0}>
                         <Button variant="outline" className="border-blue-300 hover:hover:bg-blue-300/10" type="button"><Pickaxe />创建队伍</Button>
                     </CreateTeamDialog>
                     <JoinTeamDialog 
                         game_id={gameInfo?.game_id ?? 0}
                         callback={() => {
-                        // setTimeout(() => {
-                        //     fetchGameInfoWithTeamInfo()
-                        // }, 600)
+                        mutateGameInfo()
                     }}>
                         <Button variant="outline" className="border-blue-300 hover:hover:bg-blue-300/10" type="button"><Users />加入队伍</Button>
                     </JoinTeamDialog>

--- a/clientapp/hooks/UseGame.ts
+++ b/clientapp/hooks/UseGame.ts
@@ -14,7 +14,7 @@ const fetcher = async (url: string) => {
 };
 
 export const useGame = (gameID: number) => {
-    const { data: gameInfo, error, mutate, isLoading } = useSWR<UserFullGameInfo, ErrorMessage>(`/api/game/${gameID}`, fetcher, {
+    const { data: gameInfo, error, mutate: mutateGameInfo, isLoading } = useSWR<UserFullGameInfo, ErrorMessage>(`/api/game/${gameID}`, fetcher, {
         refreshInterval: randomInt(3000, 6000)
     });
     
@@ -33,7 +33,7 @@ export const useGame = (gameID: number) => {
         mutateTeamStatus(gameInfo.team_status)
     }
     
-    return { gameInfo, error, mutate, isLoading, gameStatus, teamStatus, mutateGameStatus, mutateTeamStatus}
+    return { gameInfo, error, mutateGameInfo, isLoading, gameStatus, teamStatus, mutateGameStatus, mutateTeamStatus}
 }
 
 export const useGameDescription = (gameID: number) => {


### PR DESCRIPTION
执行比赛页面右下角的创建战队和加入战队后，应该立刻刷新一次gameInfo，获取最新的teamInfo并渲染

当前是创建或加入战队后，需要等待下一次swr轮询fetch才会获取最新的数据

在callback中使用mutateGameInfo来获取最新的game/team数据

在使用平台时发现的这个问题，修复后的这版没有本地环境测试过，目测应该没问题  :)