### PR TITLE
🚧 fix: 修复monaco-editor关闭后.monaco-aria-container仍然保留在页面中

### DIFF
--- a/clientapp/components/modules/ThemedEditor.tsx
+++ b/clientapp/components/modules/ThemedEditor.tsx
@@ -3,6 +3,7 @@ import { cn } from "lib/utils"
 import { useTheme } from "next-themes"
 import type { editor } from 'monaco-editor';
 import { loader } from '@monaco-editor/react';
+import { useEffect } from "react";
 
 import * as monaco from 'monaco-editor';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
@@ -44,7 +45,17 @@ export default function ThemedEditor(
     };
 
     loader.config({ monaco });
-    
+
+    useEffect(() => {
+        return () => {
+            // 额外清除 .monaco-aria-container 元素
+            const aria = document.querySelector(".monaco-aria-container");
+            if (aria && aria.parentNode) {
+                aria.parentNode.removeChild(aria);
+            }
+        };
+    }, []);
+        
     return (
         <div className={cn(`w-full rounded-lg ${disabled ? "pointer-events-none cursor-not-allowed opacity-50" : ""} overflow-hidden shadow-xs border-1 ${theme === "dark" ? "bg-[#1e1e1e]" : "bg-[#ffffff]"}`, className)}>
             <Editor


### PR DESCRIPTION
### 现象

在readonly的monaco-editor中尝试输入字符，会提示 `Cannot edit in read-only editor`，关闭editor后，页面中会存留 `.monaco-aria-container` ，导致其他页面会有字符残留

1. 尝试插入字符：

<img width="2492" height="1347" alt="fb6ba40e51e44178b52aecb43c0e51dc" src="https://github.com/user-attachments/assets/b07019bd-a4bb-4d0b-9788-562d96db7e76" />

2. 其他页面会存在数据残留：
<img width="2492" height="1347" alt="a952e2383dc32ab48b96c2c5690e90fb" src="https://github.com/user-attachments/assets/ca0db1b8-99db-4dda-93d0-61e2ca7531c5" />

### 修复

修复方法写的比较粗暴，在 `ThemedEditor` 中，销毁每个editor后，都把 `.monaco-aria-container` 给删除