### PR TITLE
🚧 fix:  统一使用 copy-to-clipboard 的 copy 函数复制内容到剪贴板 && 删除 ScoreBoardPage 第 418 行 的永真判断

### DIFF
--- a/clientapp/components/admin/AdminSystemLogs.tsx
+++ b/clientapp/components/admin/AdminSystemLogs.tsx
@@ -293,8 +293,7 @@ export function AdminSystemLogs() {
                     <>
                         <DropdownMenuItem
                             onClick={() => {
-                                navigator.clipboard.writeText(log.resource_id || '');
-                                toast.success('容器ID已复制到剪切板');
+                                copy(log.resource_id || '') ? toast.success('容器ID已复制到剪切板') : toast.error('复制失败');
                             }}
                         >
                             复制容器ID
@@ -304,10 +303,11 @@ export function AdminSystemLogs() {
 
                 const getDetailedLog = () => {
                     const newLog = Object.assign({}, log)
-                    const binaryString = atob(newLog.details as any)
-                    const bytes = Uint8Array.from(binaryString, c => c.charCodeAt(0))
-                    const decodedString = new TextDecoder('utf-8').decode(bytes)
-
+                    const decodedString = decodeURIComponent(
+                        atob(newLog.details as any).split('').map(
+                            (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+                        ).join('')
+                    )
                     newLog.details = JSON.parse(decodedString)
                     return JSON.stringify(newLog, null, 4)
                 }
@@ -316,7 +316,7 @@ export function AdminSystemLogs() {
                     <div className="flex gap-2 items-center">
                         <EditorDialog
                             value={getDetailedLog()}
-                            onChange={() => {}}
+                            onChange={() => { }}
                             language="json"
                             title={`查看详细信息`}
                             options={{
@@ -325,7 +325,7 @@ export function AdminSystemLogs() {
                             }}
                         >
                             <Button variant="ghost" size="icon" className='cursor-pointer'
-                                title="查看详细信息"    
+                                title="查看详细信息"
                             >
                                 <ScanEye />
                             </Button>
@@ -342,8 +342,7 @@ export function AdminSystemLogs() {
                                 {log.user_id && (
                                     <DropdownMenuItem
                                         onClick={() => {
-                                            navigator.clipboard.writeText(log.user_id || '');
-                                            toast.success('用户ID已复制到剪切板');
+                                            copy(log.user_id || '') ? toast.success('用户ID已复制到剪切板') : toast.error('复制失败');
                                         }}
                                     >
                                         复制用户ID
@@ -351,11 +350,14 @@ export function AdminSystemLogs() {
                                 )}
                                 <DropdownMenuItem
                                     onClick={() => {
-                                        const detailsText = atob(log.details as unknown as string);
-                                        const bytes = Uint8Array.from(detailsText, c => c.charCodeAt(0))
-                                        const decodedString = new TextDecoder('utf-8').decode(bytes);
-                                        copy(decodedString);
-                                        toast.success('详细信息已复制到剪切板');
+                                        const decodedString = decodeURIComponent(
+                                            atob(log.details as any).split('').map(
+                                                (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+                                            ).join('')
+                                        );
+                                        const detail = JSON.stringify(JSON.parse(decodedString), null, 4);
+                                        copy(detail || '') ? toast.success('详细信息已复制到剪切板') : toast.error('复制失败');
+
                                     }}
                                 >
                                     复制详细信息
@@ -363,8 +365,7 @@ export function AdminSystemLogs() {
                                 {log.error_message && (
                                     <DropdownMenuItem
                                         onClick={() => {
-                                            navigator.clipboard.writeText(log.error_message || '');
-                                            toast.success('错误信息已复制到剪切板');
+                                            copy(log.error_message || '') ? toast.success('错误信息已复制到剪切板') : toast.error('复制失败');
                                         }}
                                     >
                                         复制错误信息
@@ -373,8 +374,7 @@ export function AdminSystemLogs() {
                                 {log.resource_type == "CONTAINER" && containerOperations}
                                 <DropdownMenuItem
                                     onClick={() => {
-                                        navigator.clipboard.writeText(getDetailedLog());
-                                        toast.success('原始数据已复制到剪切板');
+                                        copy(getDetailedLog()) ? toast.success('原始数据已复制到剪切板') : toast.error('复制失败');
                                     }}
                                 >
                                     复制Raw

--- a/clientapp/components/admin/AdminSystemLogs.tsx
+++ b/clientapp/components/admin/AdminSystemLogs.tsx
@@ -303,11 +303,9 @@ export function AdminSystemLogs() {
 
                 const getDetailedLog = () => {
                     const newLog = Object.assign({}, log)
-                    const decodedString = decodeURIComponent(
-                        atob(newLog.details as any).split('').map(
-                            (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-                        ).join('')
-                    )
+                    const binaryString = atob(newLog.details as any)
+                    const bytes = Uint8Array.from(binaryString, c => c.charCodeAt(0))
+                    const decodedString = new TextDecoder('utf-8').decode(bytes)
                     newLog.details = JSON.parse(decodedString)
                     return JSON.stringify(newLog, null, 4)
                 }
@@ -350,11 +348,9 @@ export function AdminSystemLogs() {
                                 )}
                                 <DropdownMenuItem
                                     onClick={() => {
-                                        const decodedString = decodeURIComponent(
-                                            atob(log.details as any).split('').map(
-                                                (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-                                            ).join('')
-                                        );
+                                        const detailsText = atob(log.details as unknown as string);
+                                        const bytes = Uint8Array.from(detailsText, c => c.charCodeAt(0))
+                                        const decodedString = new TextDecoder('utf-8').decode(bytes);
                                         const detail = JSON.stringify(JSON.parse(decodedString), null, 4);
                                         copy(detail || '') ? toast.success('详细信息已复制到剪切板') : toast.error('复制失败');
 

--- a/clientapp/components/admin/game/TeamManageView.tsx
+++ b/clientapp/components/admin/game/TeamManageView.tsx
@@ -55,6 +55,7 @@ import {
 } from "components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "components/ui/avatar"
 import { copyWithResult } from "utils/ToastUtil"
+import copy from "copy-to-clipboard"
 
 export type TeamModel = {
     team_id: number,
@@ -403,7 +404,9 @@ export function TeamManageView(
                             <DropdownMenuContent align="end" >
                                 <DropdownMenuLabel>操作</DropdownMenuLabel>
                                 <DropdownMenuItem
-                                    onClick={() => navigator.clipboard.writeText(team.team_id.toString())}
+                                    onClick={() => {
+                                        copy(team.team_id.toString() || '') ? toast.success('队伍ID已复制到剪切板') : toast.error('复制失败');
+                                    }}
                                 >
                                     <ClipboardList className="h-4 w-4 mr-2" />
                                     复制队伍ID

--- a/clientapp/components/user/game/ScoreBoardPage.tsx
+++ b/clientapp/components/user/game/ScoreBoardPage.tsx
@@ -415,99 +415,99 @@ export default function ScoreBoardPage(
 
                 if (dayjs(lastestTime) > end && dayjs(gameInfo.end_time).diff(current) < 0) end = dayjs(lastestTime)
 
-                if (curTimeLine != lastTimeLine.current || true) {
-                    lastTimeLine.current = curTimeLine
+                
+                lastTimeLine.current = curTimeLine
 
-                    serialOptions.current = [
-                        {
-                            type: 'line',
-                            step: 'end',
-                            data: [],
-                            markLine:
-                                dayjs(gameInfo.end_time).diff(dayjs(), 's') < 0
-                                    ? undefined
-                                    : {
-                                        symbol: 'none',
-                                        data: [
-                                            {
-                                                xAxis: +end.toDate(),
-                                                // lineStyle: {
-                                                //     color: colorScheme === 'dark' ? "#FFFFFF" : "#000000",
-                                                //     wight: 2,
-                                                // },
-                                                label: {
-                                                    textBorderWidth: 0,
-                                                    fontWeight: 500,
-                                                    color: theme === 'dark' ? '#94a3b8' : '#64748b',
-                                                    formatter: (time: any) => dayjs(time.value).format('YYYY-MM-DD HH:mm'),
-                                                },
+                serialOptions.current = [
+                    {
+                        type: 'line',
+                        step: 'end',
+                        data: [],
+                        markLine:
+                            dayjs(gameInfo.end_time).diff(dayjs(), 's') < 0
+                                ? undefined
+                                : {
+                                    symbol: 'none',
+                                    data: [
+                                        {
+                                            xAxis: +end.toDate(),
+                                            // lineStyle: {
+                                            //     color: colorScheme === 'dark' ? "#FFFFFF" : "#000000",
+                                            //     wight: 2,
+                                            // },
+                                            label: {
+                                                textBorderWidth: 0,
+                                                fontWeight: 500,
+                                                color: theme === 'dark' ? '#94a3b8' : '#64748b',
+                                                formatter: (time: any) => dayjs(time.value).format('YYYY-MM-DD HH:mm'),
                                             },
-                                        ],
-                                    },
-                        },
-                        ...(res.data.data?.top10_timelines?.map((team, index) => {
-
-                            const lastRecordTime = team.scores?.[team.scores?.length - 1]?.record_time;
-                            const lastScore = team.scores?.[team.scores?.length - 1]?.score || 0;
-
-                            const shouldAddEnd = lastRecordTime && dayjs(lastRecordTime).isBefore(end);
-
-                            let data = [
-                                [+dayjs(gameInfo.start_time).toDate(), 0],
-                                ...(team.scores?.map((item) => [
-                                    +(item.record_time ? dayjs(item.record_time).toDate() : 0),
-                                    item.score || 0
-                                ]) || []),
-                            ];
-
-                            if (shouldAddEnd) {
-                                data.push([+end.toDate(), lastScore]);
-                            }
-
-                            return {
-                                name: team.team_name,
-                                type: 'line',
-                                showSymbol: false,
-                                step: 'end',
-                                data: data,
-                                lineStyle: {
-                                    width: 4
-                                },
-                                endLabel: {
-                                    show: true,
-                                    formatter: `${team.team_name} - ${team.scores![team.scores!.length - 1]?.score ?? 0} pts`,
-                                    color: theme === 'dark' ? '#f1f5f9' : '#0f172a',
-                                    fontWeight: 'bold',
-                                    fontSize: 12, // 稍微减小字体避免重叠
-                                    distance: 15 + (index % 3) * 8, // 动态调整距离，错开标签位置
-                                    verticalAlign: index % 2 === 0 ? 'middle' : (index % 4 < 2 ? 'top' : 'bottom'), // 垂直错开
-                                    backgroundColor: theme === 'dark' ? 'rgba(15, 23, 42, 0.9)' : 'rgba(248, 250, 252, 0.95)', // 更好的背景对比度
-                                    borderColor: theme === 'dark' ? '#334155' : '#cbd5e1',
-                                    borderWidth: 1,
-                                    borderRadius: 6,
-                                    padding: [4, 8], // 增加内边距提高可读性
-                                    shadowBlur: theme === 'dark' ? 8 : 4, // 添加阴影增强层次感
-                                    shadowColor: theme === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.1)',
-                                    shadowOffsetX: 0,
-                                    shadowOffsetY: 2,
-                                    rich: {
-                                        // 富文本样式，用于更好的标签显示
-                                        teamName: {
-                                            fontWeight: 'bold',
-                                            fontSize: 12,
-                                            color: theme === 'dark' ? '#f1f5f9' : '#0f172a'
                                         },
-                                        score: {
-                                            color: theme === 'dark' ? '#94a3b8' : '#64748b',
-                                            fontSize: 11
-                                        }
-                                    }
+                                    ],
                                 },
-                                smooth: true,
-                            }
-                        }) || [])
-                    ] as echarts.SeriesOption[]
-                }
+                    },
+                    ...(res.data.data?.top10_timelines?.map((team, index) => {
+
+                        const lastRecordTime = team.scores?.[team.scores?.length - 1]?.record_time;
+                        const lastScore = team.scores?.[team.scores?.length - 1]?.score || 0;
+
+                        const shouldAddEnd = lastRecordTime && dayjs(lastRecordTime).isBefore(end);
+
+                        let data = [
+                            [+dayjs(gameInfo.start_time).toDate(), 0],
+                            ...(team.scores?.map((item) => [
+                                +(item.record_time ? dayjs(item.record_time).toDate() : 0),
+                                item.score || 0
+                            ]) || []),
+                        ];
+
+                        if (shouldAddEnd) {
+                            data.push([+end.toDate(), lastScore]);
+                        }
+
+                        return {
+                            name: team.team_name,
+                            type: 'line',
+                            showSymbol: false,
+                            step: 'end',
+                            data: data,
+                            lineStyle: {
+                                width: 4
+                            },
+                            endLabel: {
+                                show: true,
+                                formatter: `${team.team_name} - ${team.scores![team.scores!.length - 1]?.score ?? 0} pts`,
+                                color: theme === 'dark' ? '#f1f5f9' : '#0f172a',
+                                fontWeight: 'bold',
+                                fontSize: 12, // 稍微减小字体避免重叠
+                                distance: 15 + (index % 3) * 8, // 动态调整距离，错开标签位置
+                                verticalAlign: index % 2 === 0 ? 'middle' : (index % 4 < 2 ? 'top' : 'bottom'), // 垂直错开
+                                backgroundColor: theme === 'dark' ? 'rgba(15, 23, 42, 0.9)' : 'rgba(248, 250, 252, 0.95)', // 更好的背景对比度
+                                borderColor: theme === 'dark' ? '#334155' : '#cbd5e1',
+                                borderWidth: 1,
+                                borderRadius: 6,
+                                padding: [4, 8], // 增加内边距提高可读性
+                                shadowBlur: theme === 'dark' ? 8 : 4, // 添加阴影增强层次感
+                                shadowColor: theme === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.1)',
+                                shadowOffsetX: 0,
+                                shadowOffsetY: 2,
+                                rich: {
+                                    // 富文本样式，用于更好的标签显示
+                                    teamName: {
+                                        fontWeight: 'bold',
+                                        fontSize: 12,
+                                        color: theme === 'dark' ? '#f1f5f9' : '#0f172a'
+                                    },
+                                    score: {
+                                        color: theme === 'dark' ? '#94a3b8' : '#64748b',
+                                        fontSize: 11
+                                    }
+                                }
+                            },
+                            smooth: true,
+                        }
+                    }) || [])
+                ] as echarts.SeriesOption[]
+                
                 // 结束加载状态
                 setTimeout(() => setPageLoading(false), 200)
             }).catch((_error) => {


### PR DESCRIPTION
### 修复的问题

## 1. 系统日志中文乱码

查看系统日志时发现，details字段中base64解码后中文存在乱码问题

<img width="2214" height="899" alt="image" src="https://github.com/user-attachments/assets/8c71fbc4-2ead-454f-949a-3344e3ec936a" />

~~通过使用新的base64解码算法实现修复~~

测试用的镜像是老版本的，该bug已被修复

## 2. 复制内容到粘贴板函数不统一

项目中存在使用 copy-to-clipboard 的 copy 函数的行为，同时也存在使用 navigator.clipboard.writeText 的 行为，我将 navigator.clipboard.writeText 函数均替换为了 copy 函数

## 3. ScoreBoardPage.tsx 418 行存在永真判断条件

在 npm build 的过程中，产生永真条件的告警

<img width="928" height="333" alt="ce9cba11ba2e961aebb1f025e2d639f6" src="https://github.com/user-attachments/assets/d6831f1b-25a6-4f84-876f-c2fde901ccae" />

在和项目负责人 carbofish 沟通后了解到该条件永真，将该 if 语句删除 👊
<img width="396" height="293" alt="image" src="https://github.com/user-attachments/assets/916787b6-ce2c-441c-b653-e0774edaa175" />
