### PR TITLE
🚧 fix: 修复管理员战队的逻辑，禁止其被删除或禁赛 && 修改管理员战队名称并标注slogan

### DIFF
--- a/i18n/admin.en.toml
+++ b/i18n/admin.en.toml
@@ -422,6 +422,10 @@ other = "Team approved"
 description = "Failed to ban team"
 other = "Failed to ban team"
 
+[CannotBanAdminTeam]
+description = "Cannot ban admin team"
+other = "Cannot ban admin team"
+
 [TeamBanned]
 description = "Team banned"
 other = "Team banned"
@@ -445,6 +449,10 @@ other = "Failed to delete team join requests"
 [FailedToDeleteTeam]
 description = "Failed to delete team"
 other = "Failed to delete team"
+
+[CannotDeleteAdminTeam]
+description = "Cannot delete admin team"
+other = "Cannot delete admin team"
 
 [TransactionFailed]
 description = "Transaction failed"

--- a/i18n/admin.zh.toml
+++ b/i18n/admin.zh.toml
@@ -418,6 +418,10 @@ other = "队伍已批准"
 description = "禁赛队伍失败"
 other = "禁赛队伍失败"
 
+[CannotBanAdminTeam]
+description = "管理员队伍无法被禁赛"
+other = "管理员队伍无法被禁赛"
+
 [TeamBanned]
 description = "队伍已锁定"
 other = "队伍已锁定"
@@ -441,6 +445,10 @@ other = "删除队伍加入申请失败"
 [FailedToDeleteTeam]
 description = "删除队伍失败"
 other = "删除队伍失败"
+
+[CannotDeleteAdminTeam]
+description = "管理员队伍无法被删除"
+other = "管理员队伍无法被删除"
 
 [TransactionFailed]
 description = "事务失败"

--- a/src/controllers/admin_game_controller.go
+++ b/src/controllers/admin_game_controller.go
@@ -126,13 +126,15 @@ func AdminCreateGame(c *gin.Context) {
 	}
 
 	// 创建管理员默认队伍
-	newTeam := models.Team{
+	adminTeamName := "A1CTF-Admins"
+	adminTeamSlogan := "All admins in this team"
+	adminTeam := models.Team{
 		TeamID:          0,
 		GameID:          game.GameID,
-		TeamName:        "A1CTF",
+		TeamName:        adminTeamName,
 		TeamDescription: nil,
 		TeamAvatar:      nil,
-		TeamSlogan:      nil,
+		TeamSlogan:      &adminTeamSlogan,
 		TeamMembers:     []string{},
 		TeamScore:       0,
 		TeamHash:        general.RandomHash(16),
@@ -142,7 +144,7 @@ func AdminCreateGame(c *gin.Context) {
 		TeamType:        models.TeamTypeAdmin,
 	}
 
-	if err := dbtool.DB().Create(&newTeam).Error; err != nil {
+	if err := dbtool.DB().Create(&adminTeam).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    500,
 			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "FailedToCreateAdminTeam"}),

--- a/src/controllers/admin_team_controller.go
+++ b/src/controllers/admin_team_controller.go
@@ -219,6 +219,15 @@ func AdminBanTeam(c *gin.Context) {
 		return
 	}
 
+	// 管理员队伍无法被禁赛
+	if team.TeamType == models.TeamTypeAdmin {
+		c.JSON(http.StatusForbidden, gin.H{
+			"code":    403,
+			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "CannotBanAdminTeam"}),
+		})
+		return
+	}
+
 	// 更新队伍状态为禁赛
 	oldStatus := team.TeamStatus
 	if err := dbtool.DB().Model(&team).Update("team_status", models.ParticipateBanned).Error; err != nil {
@@ -347,6 +356,15 @@ func AdminDeleteTeam(c *gin.Context) {
 				Message: i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "DatabaseError"}),
 			})
 		}
+		return
+	}
+
+	// 管理员队伍无法被删除
+	if team.TeamType == models.TeamTypeAdmin {
+		c.JSON(http.StatusForbidden, gin.H{
+			"code":    403,
+			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "CannotBanAdminTeam"}),
+		})
 		return
 	}
 


### PR DESCRIPTION
## 发现的问题

### 1. 管理员战队可以被禁赛或删除

管理员战队应该不能被禁赛或删除，代码中加上了 `TeamType` 的判断

### 2. A1CTF这个战队名称对于使用平台的管理员不太清楚作用

将默认的管理员战队名称 `A1CTF` 改为 `A1CTF-Admins`，并默认 `TeamSlogan` 为 `All admins in this team`