### PR TITLE
🚧 fix: 增加前端管理后台页面的鉴权 && 补充管理后台部分功能的title

### DIFF
--- a/clientapp/app/routes.ts
+++ b/clientapp/app/routes.ts
@@ -1,14 +1,20 @@
 import { type RouteConfig, route } from "@react-router/dev/routes";
 
 export default [
+    // 主页
     route("", "routes/A1CTFMainPage.tsx"),
-    route("games", "routes/games/UserGameList.tsx"),
 
+    // 比赛页面
+    route("games", "routes/games/UserGameList.tsx"),
     route("games/:id/:module?", "routes/games/[id]/UserGameView.tsx"),
 
+    // 关于页面
     route("about", "routes/about/SystemAboutPage.tsx"),
+
+    // 版本信息
     route("version", "routes/version/SystemVersionPage.tsx"),
 
+    // 个人设置
     route("profile/:action", "routes/profile/UserProfileSettings.tsx"),
 
     // 账户验证模块
@@ -18,28 +24,29 @@ export default [
     route("forget-password", "routes/auth/ForgetPassword.tsx"),
     route("reset-password", "routes/auth/ResetPassword.tsx"),
 
+    // 管理页面
     route("admin", "routes/admin/AdminPageMain.tsx"),
+
+    // 用户管理
+    route("admin/users", "routes/admin/users/AdminUserManage.tsx"),
+
+    // 赛题管理
     route("admin/challenges", "routes/admin/challenges/AdminGetChallengeList.tsx"),
     route("admin/challenges/:challenge_id", "routes/admin/challenges/[challenge_id]/AdminChallengeManage.tsx"),
     route("admin/challenges/create", "routes/admin/challenges/create/AdminCreateChallenge.tsx"),
 
+    // 比赛管理
     route("admin/games", "routes/admin/games/AdminListGames.tsx"),
     route("admin/games/create", "routes/admin/games/create/CreateGame.tsx"),
-
-    // 比赛管理
     route("admin/games/:game_id/:action", "routes/admin/games/[game_id]/GameSettings.tsx"),
     route("admin/games/:game_id/score-adjustments", "routes/admin/games/[game_id]/ScoreAdjustment.tsx"),
-
+    
+    // 系统日志
     route("admin/logs", "routes/admin/logs/SystemLogs.tsx"),
 
     // 系统设置
     route("admin/system/:action", "routes/admin/system/AdminSettingsPage.tsx"),
-
-    route("admin/users", "routes/admin/users/AdminUserManage.tsx"),
     
+    // 捕获所有其他路径并重定向
     route("*", "routes/PageNotFound.tsx"),
-    
-    // // 捕获所有其他路径并重定向
-    // route("*", "routes/PageNotFound.tsx")
-    // route("*", "routes/notfound.tsx")
 ] satisfies RouteConfig;

--- a/clientapp/components/modules/ClientChecker.tsx
+++ b/clientapp/components/modules/ClientChecker.tsx
@@ -1,12 +1,15 @@
 import { useGlobalVariableContext } from "contexts/GlobalVariableContext"
 import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { toast } from "react-toastify/unstyled"
+import { UserRole } from "utils/A1API"
 
 export default function () {
 
-    const { clientConfig, checkLoginStatus } = useGlobalVariableContext()
+    const { curProfile, clientConfig, checkLoginStatus } = useGlobalVariableContext()
     const navigate = useNavigate()
+    const { t } = useTranslation()
 
     const titleMap = {
         "/login": { title: "登录" },
@@ -21,6 +24,13 @@ export default function () {
         "/forget-password": { title: "忘记密码" },
         "/reset-password": { title: "重置密码" },
         "/email-verify": { title: "邮箱验证" },
+
+        // 管理后台
+        "/admin/games": { title: "比赛管理" },
+        "/admin/challenges": { title: "题目管理" },
+        "/admin/users": { title: "用户管理" },
+        "/admin/logs": { title: "系统日志" },
+        "/admin/system/[a-zA-Z0-9\\-_]+": { title: "系统设置" },
     }
 
     const unLoginAllowedPage = [
@@ -37,9 +47,12 @@ export default function () {
         "/reset-password"
     ]
 
+    const adminPagePrefix = "/admin"
+    const adminPageRoles = [UserRole.ADMIN, UserRole.MONITOR]
+
     useEffect(() => {
+        const curURL = window.location.pathname
         if (!checkLoginStatus()) {
-            const curURL = window.location.pathname
             let matched = false;
 
             unLoginAllowedPage.forEach((key) => {
@@ -52,8 +65,11 @@ export default function () {
 
             if (!matched) {
                 navigate("/login")
-                toast.error("请先登录")
+                toast.error(t("login_first"))
             }
+        } else if (curURL.startsWith(adminPagePrefix) && !adminPageRoles.includes(curProfile.role)) {
+            // 普通用户禁止访问管理后台
+            navigate("/404")
         }
     }, [window.location.pathname])
 

--- a/clientapp/public/locales/en/common.json
+++ b/clientapp/public/locales/en/common.json
@@ -17,5 +17,6 @@
     "disable_background_animation": "Disable Animation",
     "close": "Close",
     "back_to_home": "Back to home",
-    "page_not_found": "Page not found"
+    "page_not_found": "Page not found",
+    "login_first": "Please login first"
 }

--- a/clientapp/public/locales/zh/common.json
+++ b/clientapp/public/locales/zh/common.json
@@ -17,5 +17,6 @@
   "disable_background_animation": "关闭背景动画",
   "close": "关闭",
   "back_to_home": "返回主页",
-  "page_not_found": "页面未找到"
+  "page_not_found": "页面未找到",
+  "login_first": "请先登录"
 }


### PR DESCRIPTION
## 发现的问题

### 1. 当前普通用户在前端访问 /admin  路由，会跳转到管理后台

虽然跳转到管理后台没有权限执行任何操作，但是理论上来说管理后台应该只有 管理员/观察者 能够进入

### 2. 管理后台的title未指定

补充了 比赛管理、题目管理、用户管理、系统日志、系统设置 这五个 title