### PR TITLE
🚧 fix: 使用 localStorage 代替 cookie 存储客户端的 i18n 配置

### DIFF
--- a/clientapp/i18n.ts
+++ b/clientapp/i18n.ts
@@ -13,14 +13,14 @@ i18n
     defaultNS: 'common',
     supportedLngs: ['en', 'zh'],
     fallbackLng: 'en',
-    
+
     detection: {
-      order: ['path', 'cookie', 'navigator'],
+      order: ['path', 'localStorage', 'navigator'],
       lookupFromPathIndex: 0,
-      caches: ['cookie'],
-      cookieExpirationDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+      caches: ['localStorage'],
+      lookupLocalStorage: "i18next"
     },
-    
+
     backend: {
       loadPath: '/locales/{{lng}}/{{ns}}.json',
     },

--- a/clientapp/utils/A1API.ts
+++ b/clientapp/utils/A1API.ts
@@ -1133,12 +1133,12 @@ export interface AdminSubmitItem {
   challenge_name: string;
   /** 判题状态 */
   judge_status:
-    | "JudgeAC"
-    | "JudgeWA"
-    | "JudgeError"
-    | "JudgeTimeout"
-    | "JudgeQueueing"
-    | "JudgeRunning";
+  | "JudgeAC"
+  | "JudgeWA"
+  | "JudgeError"
+  | "JudgeTimeout"
+  | "JudgeQueueing"
+  | "JudgeRunning";
   /**
    * 判题时间
    * @format date-time
@@ -1184,9 +1184,9 @@ export interface AdminCheatItem {
   cheat_id: string;
   /** 作弊类型 */
   cheat_type:
-    | "SubmitSomeonesFlag"
-    | "SubmitWithoutDownloadAttachments"
-    | "SubmitWithoutStartContainer";
+  | "SubmitSomeonesFlag"
+  | "SubmitWithoutDownloadAttachments"
+  | "SubmitWithoutStartContainer";
   /** 作弊者用户名 */
   username: string;
   /** 作弊者队伍名 */
@@ -1643,7 +1643,7 @@ export class HttpClient<SecurityDataType = unknown> {
       headers: {
         ...((method &&
           this.instance.defaults.headers[
-            method.toLowerCase() as keyof HeadersDefaults
+          method.toLowerCase() as keyof HeadersDefaults
           ]) ||
           {}),
         ...(params1.headers || {}),
@@ -1721,6 +1721,7 @@ export class HttpClient<SecurityDataType = unknown> {
       headers: {
         ...(requestParams.headers || {}),
         ...(type ? { "Content-Type": type } : {}),
+        "Accept-Language": localStorage.getItem("i18next") || "en",
       },
       params: query,
       responseType: responseFormat,
@@ -2183,12 +2184,12 @@ export class Api<
           data: {
             judge_id: string;
             judge_status:
-              | "JudgeQueueing"
-              | "JudgeRunning"
-              | "JudgeError"
-              | "JudgeWA"
-              | "JudgeAC"
-              | "JudgeTimeout";
+            | "JudgeQueueing"
+            | "JudgeRunning"
+            | "JudgeError"
+            | "JudgeWA"
+            | "JudgeAC"
+            | "JudgeTimeout";
           };
         },
         void | ErrorMessage

--- a/src/utils/i18n_tool/i18n.go
+++ b/src/utils/i18n_tool/i18n.go
@@ -30,9 +30,13 @@ func LoadLanguageFiles() {
 }
 
 func Translate(c *gin.Context, config *i18n.LocalizeConfig) string {
-	language, err := c.Cookie("i18next")
-	if err != nil {
-		language = "en"
+	language := c.GetHeader("Accept-Language")
+	if language == "" {
+		if _language, err := c.Cookie("i18next"); err == nil {
+			language = _language
+		} else {
+			language = "en"
+		}
 	}
 
 	loc, ok := locMap[language]


### PR DESCRIPTION
## 发现的问题

客户端（浏览器）存储的 i18n 配置被记录在cookie中，且过期时间是 'session' ，即关闭浏览器重新打开站点， i18n 的语言选择配置会被重制

改进后使用 localStorage 来持久化存储 i18n 的语言选择配置，并且使用标准的 Accept-Language HTTP Header 向 golang 的后端发送当前选择的语言