### PR TITLE
 🚧 fix: 补充各种日志的详细信息，修复部分bug

### DIFF
--- a/src/controllers/admin_team_controller.go
+++ b/src/controllers/admin_team_controller.go
@@ -363,7 +363,7 @@ func AdminDeleteTeam(c *gin.Context) {
 	if team.TeamType == models.TeamTypeAdmin {
 		c.JSON(http.StatusForbidden, gin.H{
 			"code":    403,
-			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "CannotBanAdminTeam"}),
+			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "CannotDeleteAdminTeam"}),
 		})
 		return
 	}

--- a/src/controllers/user_challenge_controller.go
+++ b/src/controllers/user_challenge_controller.go
@@ -250,6 +250,8 @@ func UserGameChallengeSubmitFlag(c *gin.Context) {
 			"game_id":        game.GameID,
 			"team_id":        team.TeamID,
 			"user_id":        user.UserID,
+			"ingame_id":      gameChallenge.IngameID,
+			"challenge_id":   gameChallenge.Challenge.ChallengeID,
 			"challenge_name": gameChallenge.Challenge.Name,
 			"flag_content":   payload.FlagContent,
 		}, err)
@@ -269,6 +271,8 @@ func UserGameChallengeSubmitFlag(c *gin.Context) {
 		"game_id":        game.GameID,
 		"team_id":        team.TeamID,
 		"user_id":        user.UserID,
+		"ingame_id":      gameChallenge.IngameID,
+		"challenge_id":   gameChallenge.Challenge.ChallengeID,
 		"challenge_name": gameChallenge.Challenge.Name,
 		"judge_id":       newJudge.JudgeID,
 		"flag_content":   payload.FlagContent, // 只记录前50个字符

--- a/src/jobs/container_operation_job.go
+++ b/src/jobs/container_operation_job.go
@@ -76,10 +76,14 @@ func getContainerPorts(podInfo k8stool.PodInfo, task *models.Container) error {
 		}
 
 		tasks.LogContainerOperation(nil, nil, models.ActionContainerStarted, task.ContainerID, map[string]interface{}{
-			"team_hash":    task.TeamHash,
-			"ingame_id":    task.InGameID,
-			"pod_name":     podInfo.Name,
-			"container_id": task.ContainerID,
+			"game_id":               task.GameID,
+			"team_id":               task.TeamID,
+			"team_hash":             task.TeamHash,
+			"challenge_name":        task.ChallengeName,
+			"ingame_id":             task.InGameID,
+			"pod_name":              podInfo.Name,
+			"container_id":          task.ContainerID,
+			"container_expose_info": task.ContainerExposeInfos,
 		}, nil)
 	}
 
@@ -90,10 +94,14 @@ func deleteRunningPod(podInfo k8stool.PodInfo, task *models.Container) error {
 	err := k8stool.DeletePod(&podInfo)
 	if err != nil {
 		tasks.LogContainerOperation(nil, nil, models.ActionContainerStopping, task.ContainerID, map[string]interface{}{
-			"team_hash":    task.TeamHash,
-			"ingame_id":    task.InGameID,
-			"pod_name":     podInfo.Name,
-			"container_id": task.ContainerID,
+			"game_id":               task.GameID,
+			"team_id":               task.TeamID,
+			"team_hash":             task.TeamHash,
+			"challenge_name":        task.ChallengeName,
+			"ingame_id":             task.InGameID,
+			"pod_name":              podInfo.Name,
+			"container_id":          task.ContainerID,
+			"container_expose_info": task.ContainerExposeInfos,
 		}, err)
 		return fmt.Errorf("DeletePod %+v error: %v", task, err)
 	} else {
@@ -105,10 +113,14 @@ func deleteRunningPod(podInfo k8stool.PodInfo, task *models.Container) error {
 	}
 
 	tasks.LogContainerOperation(nil, nil, models.ActionContainerStopped, task.ContainerID, map[string]interface{}{
-		"team_hash":    task.TeamHash,
-		"ingame_id":    task.InGameID,
-		"pod_name":     podInfo.Name,
-		"container_id": task.ContainerID,
+		"game_id":               task.GameID,
+		"team_id":               task.TeamID,
+		"team_hash":             task.TeamHash,
+		"challenge_name":        task.ChallengeName,
+		"ingame_id":             task.InGameID,
+		"pod_name":              podInfo.Name,
+		"container_id":          task.ContainerID,
+		"container_expose_info": task.ContainerExposeInfos,
 	}, nil)
 
 	return nil

--- a/src/tasks/container_operation_task.go
+++ b/src/tasks/container_operation_task.go
@@ -136,7 +136,7 @@ func HandleContainerStopTask(ctx context.Context, t *asynq.Task) error {
 		if err := dbtool.DB().Model(&task).Updates(map[string]interface{}{
 			"container_status": models.ContainerStopped,
 		}).Error; err != nil {
-			LogContainerOperation(nil, nil, models.ActionContainerStarting, task.ContainerID, map[string]interface{}{
+			LogContainerOperation(nil, nil, models.ActionContainerStopping, task.ContainerID, map[string]interface{}{
 				"team_hash":    task.TeamHash,
 				"ingame_id":    task.InGameID,
 				"pod_name":     podInfo.Name,

--- a/src/tasks/container_operation_task.go
+++ b/src/tasks/container_operation_task.go
@@ -79,10 +79,14 @@ func HandleContainerStartTask(ctx context.Context, t *asynq.Task) error {
 	if err != nil {
 		// 记录容器创建失败日志
 		LogContainerOperation(nil, nil, models.ActionContainerStarting, task.ContainerID, map[string]interface{}{
-			"team_hash":    task.TeamHash,
-			"ingame_id":    task.InGameID,
-			"pod_name":     podInfo.Name,
-			"container_id": task.ContainerID,
+			"game_id":               task.GameID,
+			"team_id":               task.TeamID,
+			"team_hash":             task.TeamHash,
+			"challenge_name":        task.ChallengeName,
+			"ingame_id":             task.InGameID,
+			"pod_name":              podInfo.Name,
+			"container_id":          task.ContainerID,
+			"container_expose_info": task.ContainerExposeInfos,
 		}, err)
 		zaphelper.Logger.Error("CreatePod", zap.Error(err), zap.Any("task", task))
 		// 强制关闭
@@ -92,10 +96,14 @@ func HandleContainerStartTask(ctx context.Context, t *asynq.Task) error {
 		task.ContainerStatus = models.ContainerStarting
 		if err := dbtool.DB().Model(&task).Update("container_status", task.ContainerStatus).Error; err != nil {
 			LogContainerOperation(nil, nil, models.ActionContainerStarting, task.ContainerID, map[string]interface{}{
-				"team_hash":    task.TeamHash,
-				"ingame_id":    task.InGameID,
-				"pod_name":     podInfo.Name,
-				"container_id": task.ContainerID,
+				"game_id":               task.GameID,
+				"team_id":               task.TeamID,
+				"team_hash":             task.TeamHash,
+				"challenge_name":        task.ChallengeName,
+				"ingame_id":             task.InGameID,
+				"pod_name":              podInfo.Name,
+				"container_id":          task.ContainerID,
+				"container_expose_info": task.ContainerExposeInfos,
 			}, err)
 			return fmt.Errorf("failed to update container status: %v", err)
 		}
@@ -126,10 +134,14 @@ func HandleContainerStopTask(ctx context.Context, t *asynq.Task) error {
 	err := k8stool.DeletePod(&podInfo)
 	if err != nil {
 		LogContainerOperation(nil, nil, models.ActionContainerStopping, task.ContainerID, map[string]interface{}{
-			"team_hash":    task.TeamHash,
-			"ingame_id":    task.InGameID,
-			"pod_name":     podInfo.Name,
-			"container_id": task.ContainerID,
+			"game_id":               task.GameID,
+			"team_id":               task.TeamID,
+			"team_hash":             task.TeamHash,
+			"challenge_name":        task.ChallengeName,
+			"ingame_id":             task.InGameID,
+			"pod_name":              podInfo.Name,
+			"container_id":          task.ContainerID,
+			"container_expose_info": task.ContainerExposeInfos,
 		}, err)
 		return fmt.Errorf("DeletePod %+v error: %v", task, err)
 	} else {
@@ -137,20 +149,28 @@ func HandleContainerStopTask(ctx context.Context, t *asynq.Task) error {
 			"container_status": models.ContainerStopped,
 		}).Error; err != nil {
 			LogContainerOperation(nil, nil, models.ActionContainerStopping, task.ContainerID, map[string]interface{}{
-				"team_hash":    task.TeamHash,
-				"ingame_id":    task.InGameID,
-				"pod_name":     podInfo.Name,
-				"container_id": task.ContainerID,
+				"game_id":               task.GameID,
+				"team_id":               task.TeamID,
+				"team_hash":             task.TeamHash,
+				"challenge_name":        task.ChallengeName,
+				"ingame_id":             task.InGameID,
+				"pod_name":              podInfo.Name,
+				"container_id":          task.ContainerID,
+				"container_expose_info": task.ContainerExposeInfos,
 			}, err)
 			return fmt.Errorf("failed to update container status: %v", err)
 		}
 	}
 
 	LogContainerOperation(nil, nil, models.ActionContainerStopped, task.ContainerID, map[string]interface{}{
-		"team_hash":    task.TeamHash,
-		"ingame_id":    task.InGameID,
-		"pod_name":     podInfo.Name,
-		"container_id": task.ContainerID,
+		"game_id":               task.GameID,
+		"team_id":               task.TeamID,
+		"team_hash":             task.TeamHash,
+		"challenge_name":        task.ChallengeName,
+		"ingame_id":             task.InGameID,
+		"pod_name":              podInfo.Name,
+		"container_id":          task.ContainerID,
+		"container_expose_info": task.ContainerExposeInfos,
 	}, nil)
 
 	return nil
@@ -181,10 +201,14 @@ func HandleContainerFailedTask(ctx context.Context, t *asynq.Task) error {
 	err := k8stool.DeletePod(&podInfo)
 	if err != nil {
 		LogContainerOperation(nil, nil, models.ActionContainerFailed, task.ContainerID, map[string]interface{}{
-			"team_hash":    task.TeamHash,
-			"ingame_id":    task.InGameID,
-			"pod_name":     podInfo.Name,
-			"container_id": task.ContainerID,
+			"game_id":               task.GameID,
+			"team_id":               task.TeamID,
+			"team_hash":             task.TeamHash,
+			"challenge_name":        task.ChallengeName,
+			"ingame_id":             task.InGameID,
+			"pod_name":              podInfo.Name,
+			"container_id":          task.ContainerID,
+			"container_expose_info": task.ContainerExposeInfos,
 		}, err)
 		return fmt.Errorf("DeletePod %+v error: %v", task, err)
 	} else {
@@ -192,21 +216,29 @@ func HandleContainerFailedTask(ctx context.Context, t *asynq.Task) error {
 			"container_status": models.ContainerError,
 		}).Error; err != nil {
 			LogContainerOperation(nil, nil, models.ActionContainerFailed, task.ContainerID, map[string]interface{}{
-				"team_hash":    task.TeamHash,
-				"ingame_id":    task.InGameID,
-				"pod_name":     podInfo.Name,
-				"container_id": task.ContainerID,
+				"game_id":               task.GameID,
+				"team_id":               task.TeamID,
+				"team_hash":             task.TeamHash,
+				"challenge_name":        task.ChallengeName,
+				"ingame_id":             task.InGameID,
+				"pod_name":              podInfo.Name,
+				"container_id":          task.ContainerID,
+				"container_expose_info": task.ContainerExposeInfos,
 			}, err)
 			return fmt.Errorf("failed to update container status: %v", err)
 		}
 	}
 
 	LogContainerOperation(nil, nil, models.ActionContainerFailed, task.ContainerID, map[string]interface{}{
-		"team_hash":    task.TeamHash,
-		"ingame_id":    task.InGameID,
-		"pod_name":     podInfo.Name,
-		"container_id": task.ContainerID,
-		"reason":       podStatus.Message,
+		"game_id":               task.GameID,
+		"team_id":               task.TeamID,
+		"team_hash":             task.TeamHash,
+		"challenge_name":        task.ChallengeName,
+		"ingame_id":             task.InGameID,
+		"pod_name":              podInfo.Name,
+		"container_id":          task.ContainerID,
+		"container_expose_info": task.ContainerExposeInfos,
+		"reason":                podStatus.Message,
 	}, fmt.Errorf("failed to open container"))
 
 	return nil

--- a/src/utils/general/compare_helper.go
+++ b/src/utils/general/compare_helper.go
@@ -1,0 +1,14 @@
+package general
+
+func CompareStringPtrEquals(a, b *string) bool {
+	// 如果两个指针都指向 nil，则认为相等
+	if a == nil && b == nil {
+		return true
+	}
+	// 如果只有一个指针是 nil，则不相等
+	if a == nil || b == nil {
+		return false
+	}
+	// 比较指针指向的实际字符串值
+	return *a == *b
+}


### PR DESCRIPTION
## 问题

### 1. 删除管理员战队的i18n错误

删除管理员战队的i18n的key应该是`CannotDeleteAdminTeam`而不是`CannotBanAdminTeam`

### 2. 用户登陆日志信息补充

补充用户登陆日志中的上次登录时间和IP的信息

### 3. 用户提交flag缺少challenge_id

补充用户提交flag时的challenge_id和ingame_id

### 4. 补充系统操作容器的日志内容

fix: 
- 修复 HandleContainerStopTask 中的日志action
- old_expire_time 和 new_expire_time 在 gorm updates 之后相等，应该在updates之前存一份 old_expire_time 进行记录
- 到期时间大于半小时的不可延长，逻辑应该用 大于号
- 系统 创建/销毁/失败 容器的日志，增加 game_id、team_id、challenge_name、container_expose_info 信息

### 5. 优化管理员修改用户信息的日志

只记录被修改的用户信息的数据