### PR TITLE
🚧 fix: 修复前端部分组件 & 修复后端 AdminCreateNotice 的异步写入问题

### DIFF
--- a/clientapp/app/routes/admin/system/AdminSettingsPage.tsx
+++ b/clientapp/app/routes/admin/system/AdminSettingsPage.tsx
@@ -280,10 +280,10 @@ export const AdminSettingsPage = () => {
                     <div className="flex flex-1 h-full overflow-hidden">
                         {activeModule == "aboutus" ? (
                             <div className="w-full h-full">
-                                <AboutPage
+                                {dataLoaded && <AboutPage
                                     form={form}
                                     onSubmit={onSubmit}
-                                />
+                                />}
                             </div>
                         ) : (
                             <MacScrollbar className="w-full h-full overflow-hidden select-none"

--- a/clientapp/components/admin/AboutPage.tsx
+++ b/clientapp/components/admin/AboutPage.tsx
@@ -20,7 +20,7 @@ export default function AboutPage(
     const [debouncedSource, setDebouncedSource] = useState<string>("");
     const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-    const {t} = useTranslation("system_settings")
+    const { t } = useTranslation("system_settings")
 
     // 防抖函数
     const debouncedUpdateSource = useCallback((value: string) => {
@@ -54,7 +54,7 @@ export default function AboutPage(
 
     useEffect(() => {
         setAboutMeSource(watchValue || "A1CTF Platform")
-        debouncedUpdateSource(watchValue || "A1CTF Platform");
+        setDebouncedSource(watchValue || "A1CTF Platform")
     }, [watchValue])
 
     const { theme } = useTheme()
@@ -86,7 +86,7 @@ export default function AboutPage(
                         />
                     </div>
                     <div className='h-full w-1/2 border-2 rounded-md overflow-hidden relative'>
-                        
+
                         <MacScrollbar className='h-full w-full select-none'
                             skin={theme == "light" ? "light" : "dark"}
                         >

--- a/clientapp/components/admin/GameNoticeManager.tsx
+++ b/clientapp/components/admin/GameNoticeManager.tsx
@@ -159,8 +159,8 @@ export function GameNoticeManager({ gameId }: GameNoticeManagerProps) {
                 ) : notices.length === 0 ? (
                     <div className="text-center py-12">
                         <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                        <h3 className="text-lg font-semibold mb-2">{t("list.empty")}</h3>
-                        <p className="text-muted-foreground">{t("list.first")}</p>
+                        <h3 className="text-lg font-semibold mb-2">{t("notice.list.empty")}</h3>
+                        <p className="text-muted-foreground">{t("notice.list.first")}</p>
                     </div>
                 ) : (
                     <div className="space-y-4 pr-4">

--- a/clientapp/components/admin/game/ContainerManageView.tsx
+++ b/clientapp/components/admin/game/ContainerManageView.tsx
@@ -135,6 +135,7 @@ export function ContainerManageView({
     // 多终端数组
     type TerminalInstance = {
         id: string;
+        teamName: string;
         podName: string;
         containerName: string;
         isOpen: boolean;
@@ -453,7 +454,7 @@ export function ContainerManageView({
                                                     // 重新打开已存在的终端
                                                     return prev.map(t => t.id === id ? { ...t, isOpen: true } : t);
                                                 }
-                                                return [...prev, { id, podName: container.pod_id ?? "", containerName: e, isOpen: true }];
+                                                return [...prev, { id, teamName: container?.team_name ?? "", podName: container?.pod_id ?? "", containerName: e, isOpen: true }];
                                             });
                                         }}>
                                             <Package />
@@ -560,6 +561,7 @@ export function ContainerManageView({
             {terminals.map(t => t.isOpen && (
                 <ContainerTerminal
                     key={t.id}
+                    teamName={t.teamName}
                     podName={t.podName}
                     containerName={t.containerName}
                     isOpen={t.isOpen}

--- a/clientapp/utils/ApiHelper.ts
+++ b/clientapp/utils/ApiHelper.ts
@@ -89,7 +89,7 @@ const handleGlobalError = (error: any, config?: any) => {
             } else if (data.detail) {
                 errorMessage = data.detail;
             }
-        } else if (typeof data === 'string') {
+        } else if (typeof data === 'string' && data.length > 0) {
             errorMessage = data;
         } else {
             // 根据状态码提供默认错误信息
@@ -185,7 +185,7 @@ export interface ErrorMessage {
 // 标记错误为已处理，防止全局错误处理器重复处理
 export const markErrorAsHandled = (error: any) => {
     if (error && typeof error === 'object') {
-        
+
         error._isHandled = true;
     }
     return error;

--- a/clientapp/utils/ToastUtil.tsx
+++ b/clientapp/utils/ToastUtil.tsx
@@ -3,15 +3,68 @@ import copy from "copy-to-clipboard";
 import dayjs from "dayjs";
 import i18n from "i18n";
 import { CalendarClock, CircleX, FileType2, LetterText, MailCheck, PackageOpen, Text } from "lucide-react";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState, useEffect } from "react";
 import { toast } from "react-toastify/unstyled";
 import { toast as OldToast } from 'sonner'
 
-export function toastNewNotice({ title, time, openNotices }: { title: string, time: string, openNotices: Dispatch<SetStateAction<boolean>> }) {
+function ToastWrapper({
+    t,
+    duration,
+    children,
+}: {
+    t: string | number;
+    duration: number;
+    children: React.ReactNode;
+}) {
+    const [progress, setProgress] = useState(100);
 
-    OldToast.custom((t) => (
-        <div className="bg-background/90 border-1 rounded-2xl w-full relative">
-            <div className="flex flex-col justify-center gap-2 p-4 pl-4 pr-4">
+    useEffect(() => {
+        const start = Date.now();
+        const timer = setInterval(() => {
+            const elapsed = Date.now() - start;
+            const percent = Math.max(0, 100 - (elapsed / duration) * 100);
+            setProgress(percent);
+
+            if (elapsed >= duration) {
+                clearInterval(timer);
+                OldToast.dismiss(t);
+            }
+        }, 100);
+
+        return () => clearInterval(timer);
+    }, [t, duration]);
+
+    return (
+        <div className="bg-background/90 border rounded-2xl w-full relative overflow-hidden">
+            {/* 顶部进度条 */}
+            <div className="absolute top-0 left-0 w-full h-1 bg-muted">
+                <div
+                    className="h-1 bg-gradient-to-r from-red-500 via-orange-500 to-green-500 transition-all duration-100 ease-linear"
+                    style={{ width: `${progress}%` }}
+                />
+            </div>
+
+            {/* 内容 */}
+            <div className="flex flex-col justify-center gap-2 p-4">
+                {children}
+            </div>
+        </div>
+    );
+}
+
+export function toastNewNotice({
+    title,
+    time,
+    openNotices,
+}: {
+    title: string;
+    time: string;
+    openNotices: Dispatch<SetStateAction<boolean>>;
+}) {
+    const DURATION = 60000;
+    OldToast.custom(
+        (t) => (
+            <ToastWrapper t={t} duration={DURATION}>
                 <div className="flex gap-2 items-center">
                     <MailCheck size={20} className="flex-none" />
                     <span className="text-sm">{i18n.t("toast.notice.title")}</span>
@@ -22,58 +75,82 @@ export function toastNewNotice({ title, time, openNotices }: { title: string, ti
                 </div>
                 <div className="flex gap-2">
                     <FileType2 size={20} className="flex-none" />
-                    <span className="text-sm">{title.substring(0, Math.min(title.length, 50)) + ((title.length > 50) ? "…" : "")}</span>
+                    <span className="text-sm">
+                        {title.substring(0, Math.min(title.length, 50)) +
+                            (title.length > 50 ? "…" : "")}
+                    </span>
                 </div>
                 <div className="flex gap-4 mt-2 justify-center">
-                    <Button variant="outline" className="flex" onClick={() => {
-                        toast.dismiss(t)
-                        setTimeout(() => {
-                            openNotices(true)
-                        }, 300)
-                    }}>
+                    <Button
+                        variant="outline"
+                        className="flex"
+                        onClick={() => {
+                            OldToast.dismiss(t);
+                            setTimeout(() => openNotices(true), 300);
+                        }}
+                    >
                         <div className="flex items-center gap-1">
                             <PackageOpen />
                             <span>{i18n.t("toast.notice.open")}</span>
                         </div>
                     </Button>
-                    <Button variant="outline" onClick={() => OldToast.dismiss(t)}><CircleX /> {i18n.t("close")}</Button>
+                    <Button
+                        variant="outline"
+                        onClick={() => OldToast.dismiss(t)}
+                        className="flex items-center gap-1"
+                    >
+                        <CircleX /> {i18n.t("close")}
+                    </Button>
                 </div>
-            </div>
-        </div>
-    ), {
-        duration: 600000,
-        position: "top-center"
-    })
-
+            </ToastWrapper>
+        ),
+        {
+            duration: DURATION,
+            position: "top-center",
+        }
+    );
 }
 
-export function toastNewHint({ challenges, time, openNotices: _openNotices }: { challenges: string[], time: number, openNotices: Dispatch<SetStateAction<boolean>> }) {
-
-    OldToast.custom((t) => (
-        <div className="bg-background/80 border-1 rounded-2xl w-full relative">
-            <div className="flex flex-col justify-center gap-2 p-4 pl-4 pr-4">
+export function toastNewHint({
+    challenges,
+    time,
+}: {
+    challenges: string[];
+    time: number;
+    openNotices: Dispatch<SetStateAction<boolean>>;
+}) {
+    const DURATION = 60000;
+    OldToast.custom(
+        (t) => (
+            <ToastWrapper t={t} duration={DURATION}>
                 <div className="flex gap-2 items-center">
                     <Text size={20} className="flex-none" />
                     <span className="text-sm">{i18n.t("toast.hint.title")}</span>
                 </div>
                 <div className="flex gap-2 items-center">
                     <CalendarClock size={20} />
-                    <span className="text-sm">{dayjs(time * 1000).format("YYYY-MM-DD HH:mm:ss")}</span>
+                    <span className="text-sm">
+                        {dayjs(time * 1000).format("YYYY-MM-DD HH:mm:ss")}
+                    </span>
                 </div>
                 <div className="flex gap-2">
                     <LetterText size={20} className="flex-none" />
-                    <span className="text-sm">{i18n.t("toast.hint.content", { name: challenges.join(", ") })}</span>
+                    <span className="text-sm">
+                        {i18n.t("toast.hint.content", { name: challenges.join(", ") })}
+                    </span>
                 </div>
                 <div className="flex gap-4 mt-2 justify-center">
-                    <Button variant="outline" onClick={() => OldToast.dismiss(t)}><CircleX /> {i18n.t("close")}</Button>
+                    <Button variant="outline" onClick={() => OldToast.dismiss(t)}>
+                        <CircleX /> {i18n.t("close")}
+                    </Button>
                 </div>
-            </div>
-        </div>
-    ), {
-        duration: 600000,
-        position: "top-center",
-    })
-
+            </ToastWrapper>
+        ),
+        {
+            duration: DURATION,
+            position: "top-center",
+        }
+    );
 }
 
 export const copyWithResult = (text: any, field: string = "") => {

--- a/src/controllers/admin_game_controller.go
+++ b/src/controllers/admin_game_controller.go
@@ -410,9 +410,7 @@ func AdminUpdateGameChallenge(c *gin.Context) {
 	}
 
 	if shouldSendNotice {
-		go func() {
-			noticetool.InsertNotice(gameID, models.NoticeNewHint, noticeData)
-		}()
+		noticetool.InsertNotice(gameID, models.NoticeNewHint, noticeData)
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -603,9 +601,7 @@ func AdminCreateNotice(c *gin.Context) {
 	}
 
 	// 使用 notice_tool 插入公告
-	go func() {
-		noticetool.InsertNotice(gameID, models.NoticeNewAnnounce, []string{payload.Title, payload.Content})
-	}()
+	noticetool.InsertNotice(gameID, models.NoticeNewAnnounce, []string{payload.Title, payload.Content})
 
 	c.JSON(http.StatusOK, gin.H{
 		"code":    200,

--- a/src/utils/notice_tool/notice_tool.go
+++ b/src/utils/notice_tool/notice_tool.go
@@ -20,10 +20,11 @@ func InsertNotice(gameID int64, category models.NoticeCategory, values []string)
 		Data:           pq.StringArray(values),
 	}
 
+	// 写入db是同步的，通知是异步的
 	if err := dbtool.DB().Create(&notice).Error; err != nil {
 		zaphelper.Logger.Error("Failed to insert notice", zap.Error(err))
 	} else {
-		AnnounceNotice(notice)
+		go func() { AnnounceNotice(notice) }()
 	}
 }
 


### PR DESCRIPTION
## 存在的问题

### 1. AboutPage刷新时form.aboutus数据不存在

由于上一级页面 AdminSettingsPage 没有等待数据加载完毕就对 AboutPage 进行渲染，导致form数据在初始化的时候获取不到

解决方法：等待 dataLoaded 后再渲染 AboutPage

<img width="2492" height="1347" alt="image" src="https://github.com/user-attachments/assets/64eddbab-1678-4b0f-8f6b-b249faf89054" />

### 2. 后端AdminCreateNotice异步写入问题

后端 AdminCreateNotice 写入db是异步的，导致前端 GameNoticeManager 新增notice后，获取新的list大概率无法获取新增的那一条notice

解决方法：同步调用 noticetool.InsertNotice，在函数内部异步调用 AnnounceNotice

### 3. ApiHelper处理错误时的toast为空

如果api发生错误，status在 [400, 401, 403, 404, 500, 502, 503, 504] 中，但是 http response 的 data 也是空的，会导致toast.error的是一个空字符串

解决方法：判断response data是否是空字符串，是的话就进入 根据状态码提供默认错误信息 的逻辑

### 4. Terminal拖拽问题 & xterm高度问题

由于ContainerTerminal是由rnd包裹一个标题栏和终端内容实现的，导致css计算xterm的高度存在问题

由于rnd没有设置可拖拽的class，导致整个终端都会被拖拽，无法进行终端内容的选择

解决方法：设置rnd的可拖拽class，绑定为标题栏；标题栏和终端内容使用额外的一个flex div包裹，css设置正确后，修复计算xterm的高度再resize。在之前的基础上，新增了容器终端websocket连接时的spinner加载动画，限制了rnd的最小高度和最小宽度

### 5. ToastUitl 默认消失时间错误

由于错误的设置ToastUtil的时间，10分钟弹窗才能消失；noticeToast的 打开公告 按钮，没有正确的关闭弹窗

解决方法：将600s（10mins）改成60s，并且新增了弹窗顶部的彩色消失进度条，60s后自动关闭；修复公告弹窗的正确关闭函数

<img width="664" height="380" alt="image" src="https://github.com/user-attachments/assets/dc673b10-f7aa-4d32-882a-67cb8d18d530" />
<img width="733" height="369" alt="image" src="https://github.com/user-attachments/assets/7fe1fc25-8ef6-4351-90e9-f0d7dd3d2cf4" />

