### PR TITLE
🚧 fix: 适配 ContainerManageView 页面的 i18n & 优化后端容器相关操作 & 修复 container-cooldown-time 的配置读取

### DIFF
--- a/clientapp/components/admin/GameGroupManager.tsx
+++ b/clientapp/components/admin/GameGroupManager.tsx
@@ -224,7 +224,7 @@ export function GameGroupManager({ gameId }: GameGroupManagerProps) {
                             <TableHead>{t("group.add.name.label")}</TableHead>
                             <TableHead>{t("group.add.info.label")}</TableHead>
                             <TableHead>{t("group.time")}</TableHead>
-                            <TableHead className="text-right">{t("group.action")}</TableHead>
+                            <TableHead className="text-right">{t("action")}</TableHead>
                         </TableRow>
                     </TableHeader>
                     <TableBody>

--- a/clientapp/components/admin/game/ChallengeManageSheet.tsx
+++ b/clientapp/components/admin/game/ChallengeManageSheet.tsx
@@ -41,6 +41,9 @@ export default function ChallengeManageSheet(
     }
 ) {
 
+    // 初始化的时候加载 game_edit 的 i18n，防止切换到容器管理和事件管理的时候页面会有感刷新
+    useTranslation("game_edit")
+
     const { t } = useTranslation("challenge_manage")
     const { theme } = useTheme()
     const [isOpen, setIsOpen] = useState(false)

--- a/clientapp/components/admin/game/ContainerManageView.tsx
+++ b/clientapp/components/admin/game/ContainerManageView.tsx
@@ -37,7 +37,7 @@ import {
     TableRow,
 } from "components/ui/table"
 
-import { api } from "utils/ApiHelper";
+import { api, createSkipGlobalErrorConfig } from "utils/ApiHelper";
 import { Badge } from "components/ui/badge";
 import {
     AlertDialog,
@@ -225,7 +225,7 @@ export function ContainerManageView({
 
     const submitExtendContainer = (containerId: string) => {
         toast.promise(
-            api.admin.adminExtendContainer({ container_id: containerId }),
+            api.admin.adminExtendContainer({ container_id: containerId }, createSkipGlobalErrorConfig()),
             {
                 pending: t("container.extend.pending"),
                 success: { render() { fetchContainers(); return t("container.extend.success"); } },
@@ -437,6 +437,7 @@ export function ContainerManageView({
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <Button
+                                    disabled={container.container_status !== ContainerStatus.ContainerRunning}
                                     variant="ghost"
                                     className="h-8 w-8 p-0 text-blue-600"
                                     data-tooltip-id="my-tooltip"
@@ -504,6 +505,7 @@ export function ContainerManageView({
                                     {t("container.terminal.copy.pod")}
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
+                                    disabled={container.container_status !== ContainerStatus.ContainerRunning}
                                     onClick={() => submitExtendContainer(container.container_id)}
                                     className="text-blue-600"
                                 >

--- a/clientapp/components/admin/game/TeamManageView.tsx
+++ b/clientapp/components/admin/game/TeamManageView.tsx
@@ -379,7 +379,7 @@ export function TeamManageView(
         },
         {
             id: "actions",
-            header: t("group.action"),
+            header: t("action"),
             enableHiding: false,
             cell: ({ row }) => {
                 const team = row.original;
@@ -406,7 +406,7 @@ export function TeamManageView(
                                 </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" >
-                                <DropdownMenuLabel>{t("group.action")}</DropdownMenuLabel>
+                                <DropdownMenuLabel>{t("action")}</DropdownMenuLabel>
                                 <DropdownMenuItem
                                     onClick={() => {
                                         copyWithResult(team.team_id || '', t("events.filter.team_id"))

--- a/clientapp/components/modules/terminal/Terminal.tsx
+++ b/clientapp/components/modules/terminal/Terminal.tsx
@@ -186,7 +186,7 @@ function MyTerminal({
     return (
         <div
             ref={ref as any}
-            className="w-full h-full bg-[#0f1720] p-2 rounded-b-md box-border"
+            className="w-full h-full bg-[#0f1720] p-2 rounded-b-md"
         />
     );
 }

--- a/clientapp/public/locales/en/game_edit.json
+++ b/clientapp/public/locales/en/game_edit.json
@@ -3,6 +3,7 @@
         "prev": "Prev",
         "next": "Next"
     },
+    "action": "Actions",
     "events": {
         "title": "Game Events",
         "auto": "Auto Update",
@@ -190,7 +191,6 @@
         },
         "option": "Optional",
         "time": "Created At",
-        "action": "Actions",
         "empty": "No groups yet. Click \"Create Group\" to add one"
     },
     "notice": {
@@ -272,5 +272,70 @@
         "row": "Columns",
         "select": "{{a}} / {{b}} rows selected",
         "support": "Supports team name, team ID, member username, member user ID, invite code, team hash, team slogan"
+    },
+    "container": {
+        "status": {
+            "running": "Running",
+            "stopped": "Stopped",
+            "starting": "Starting",
+            "error": "Error",
+            "stopping": "Stopping",
+            "queueing": "Queued",
+            "empty": "No Containers",
+            "unknow": "Unknown"
+        },
+        "table": {
+            "select": {
+                "header": "Select All",
+                "cell": "Select Row"
+            },
+            "expire": "Expiration Time",
+            "ports": "Access Endpoints",
+            "no_port": "No Available Links"
+        },
+        "stop": {
+            "stop": "Stop Container",
+            "title": "Confirm Stop",
+            "description": "Are you sure you want to stop this container?",
+            "pending": "Stopping container...",
+            "success": "Container is stopping",
+            "error": "Failed to stop container",
+            "batch": {
+                "title": "Batch Stop ({{count}})",
+                "select": "Please select at least one container",
+                "confirm": "Confirm Batch Stop",
+                "description": "Are you sure you want to stop the selected {{count}} containers?",
+                "pending": "Stopping {{count}} containers...",
+                "success1": "Successfully stopped {{count}} containers",
+                "success2": "Stopped {{s}} containers successfully, failed {{f}}",
+                "error": "Failed to batch stop containers"
+            }
+        },
+        "extend": {
+            "title": "Extend Container Time",
+            "pending": "Extending container time...",
+            "success": "Container time extended",
+            "error": "Failed to extend container time"
+        },
+        "flag": {
+            "title": "Copy Flag",
+            "pending": "Retrieving flag from container...",
+            "success": "Flag copied to clipboard",
+            "error": "Failed to retrieve container flag"
+        },
+        "terminal": {
+            "title": "Container Terminal",
+            "select": "Select One",
+            "copy": {
+                "id": "Copy Container ID",
+                "pod": "Copy Pod ID"
+            }
+        },
+        "search": "Supports team ID, Pod ID, container ID, team name, challenge name, challenge ID, team ID",
+        "show": {
+            "error": "Show Error Containers",
+            "item": "Show Items"
+        },
+        "empty": "No container data"
     }
 }

--- a/clientapp/public/locales/zh/game_edit.json
+++ b/clientapp/public/locales/zh/game_edit.json
@@ -3,6 +3,7 @@
         "prev": "上一页",
         "next": "下一页"
     },
+    "action": "操作",
     "events": {
         "title": "比赛事件",
         "auto": "自动更新",
@@ -190,7 +191,6 @@
         },
         "option": "可选",
         "time": "创建时间",
-        "action": "操作",
         "empty": "暂无分组，点击\"创建分组\"开始添加"
     },
     "notice": {
@@ -268,9 +268,74 @@
             "title": "打开菜单",
             "copy": "复制队伍ID"
         },
-        "empty":"暂无队伍数据",
+        "empty": "暂无队伍数据",
         "row": "列显示",
         "select": "{{a}} / {{b}} 行已选择",
         "support": "支持队伍名, 队伍ID, 成员用户名, 成员用户ID, 邀请码, 队伍Hash, 队伍口号"
+    },
+    "container": {
+        "status": {
+            "running": "运行中",
+            "stopped": "已停止",
+            "starting": "启动中",
+            "error": "错误",
+            "stopping": "停止中",
+            "queueing": "队列中",
+            "empty": "无容器",
+            "unknow": "未知"
+        },
+        "table": {
+            "select": {
+                "header": "全选",
+                "cell": "选择行"
+            },
+            "expire": "过期时间",
+            "ports": "访问入口",
+            "no_port": "无可用链接"
+        },
+        "stop": {
+            "stop": "停止容器",
+            "title": "确认停止",
+            "description": "您确定要停止这个容器吗？",
+            "pending": "正在停止容器...",
+            "success": "容器正在停止",
+            "error": "停止容器失败",
+            "batch": {
+                "title": "批量停止 ({{count}})",
+                "select": "请至少选择一个容器",
+                "confirm": "确认批量停止",
+                "description": "您确定要停止选中的 {{count}} 个容器吗？",
+                "pending": "正在停止 {{count}} 个容器...",
+                "success1": "成功停止 {{count}} 个容器",
+                "success2": "成功停止容器 {{s}} 个，失败 {{f}} 个",
+                "error": "批量停止容器失败"
+            }
+        },
+        "extend": {
+            "title": "延长容器时间",
+            "pending": "正在延长容器时间...",
+            "success": "容器时间已延长",
+            "error": "延长容器时间失败"
+        },
+        "flag": {
+            "title": "复制Flag",
+            "pending": "正在获取容器中的Flag...",
+            "success": "Flag已复制到剪贴板",
+            "error": "获取容器Flag失败"
+        },
+        "terminal": {
+            "title": "容器终端",
+            "select": "选择一个容器",
+            "copy": {
+                "id": "复制容器ID",
+                "pod": "复制PodID"
+            }
+        },
+        "search": "支持队伍ID, PodID, 容器ID, 队伍名称, 题目名称, 题目ID, 队伍ID",
+        "show": {
+            "error": "显示错误容器",
+            "item": "显示项目"
+        },
+        "empty": "暂无容器数据"
     }
 }


### PR DESCRIPTION
## 发现的问题

### container-cooldown-time 配置读取错误

由于错误的在global区在viper未初始化的条件下就使用viper读取了配置，导致容器相关操作的 timeLimit 永远是 60s

修复方法就是在每次执行容器相关操作的时候，再读取viper的配置

### 用户 开启/关闭 容器没有立刻执行容器task

应该在用户 开启/关闭 容器的时候，主动调用异步的容器task，加快容器操作

能够优化的场景：

用户设置 job-intervals.container-updating 是 60s，如果用户点击关闭容器，在原逻辑下最长需要等待2分钟才会彻底删除这个容器（1分钟设置为 stoppind，1分钟设置为stopped），优化后只需要1分钟

用户设置 job-intervals.container-updating 是 60s，如果用户点击开启容器，在原逻辑下（假设k8s开启pod的时间小于60s），用户最长需要等待2分钟才能拿到容器信息（1分钟从queueing设置为starting，1分钟从starting设置为started），优化后只需要1分钟

### 优化UpdateLivingContainers遍历container的逻辑

优化执行顺序：

在遍历容器的时候，先判断是否过期或者启动超时，这样就能在下面的判断stopping的时候顺便把容器给销毁，无需等待下一次 UpdateLivingContainers 的 job 再去销毁