### PR TITLE
fix: 修复警告弹窗的标题拼写错误

### DIFF
--- a/clientapp/public/locales/en/challenge_manage.json
+++ b/clientapp/public/locales/en/challenge_manage.json
@@ -1,6 +1,6 @@
 {
     "delete": "Delete Challenge",
-    "alert_title": "Warnning",
+    "alert_title": "Warning",
     "save": "Save",
     "close": "Close",
     "delete_description": "Are you sure you want to delete this challenge? (This action is irreversible!)",


### PR DESCRIPTION
<img width="1874" height="954" alt="image" src="https://github.com/user-attachments/assets/b517ce9e-8e9e-4b25-b2fb-eca6183320e4" />

如图拼错了，看到顺带修了一下