### PR TITLE
fix: 修复在容器设置中内存输入框顶上错误的 label 显示

### DIFF
--- a/clientapp/components/admin/EditChallengeView.tsx
+++ b/clientapp/components/admin/EditChallengeView.tsx
@@ -230,7 +230,7 @@ function ContainerForm({ control, index, removeContainer }: ContainerFormProps) 
                     render={({ field }) => (
                         <FormItem>
                             <div className="flex items-center h-[20px]">
-                                <FormLabel>{t("container.limit.cpu.label")}</FormLabel>
+                                <FormLabel>{t("container.limit.mem.label")}</FormLabel>
                                 <div className="flex-1" />
                                 <FormMessage className="text-[14px]" />
                             </div>


### PR DESCRIPTION
RT，设置内存的地方顶上的 Label 错了

<img width="3420" height="2224" alt="CleanShot_2026-05-28_16 18 25@2x" src="https://github.com/user-attachments/assets/ee13755d-60c6-4ebc-a141-a380bb239885" />
