### PR TITLE
fix(security): timing attack protection, container security context, pod name validation, RandomHash entropy

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,7 +18,11 @@ system:
   # make sure that you include your reverse proxy server's ip in this list
   # don't use 0.0.0.0/0, it's dangerous
   trusted-proxies:
-    - 0.0.0.0/0
+    # WARNING: Do not use 0.0.0.0/0 in production.
+    # Only add your reverse proxy IP addresses here.
+    - 127.0.0.1/32
+  # CSRF protection secret (separate from JWT). Generate with: openssl rand -base64 32
+  csrf-secret: "change-me-in-production-please-use-openssl-rand-base64-32"
   # enable pprof for performance profiling, default is false
   pprof-enable: false
 

--- a/src/controllers/admin_challenge_controller.go
+++ b/src/controllers/admin_challenge_controller.go
@@ -144,11 +144,11 @@ func AdminCreateChallenge(c *gin.Context) {
 	payload.ChallengeID = nil
 
 	if err := dbtool.DB().Create(&payload).Error; err != nil {
+		log.Errorf("Failed to create challenge: %+v, error: %v", payload, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    500,
 			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "FailedToCreateChallenge"}),
 		})
-		log.Panicf("%+v %v\n", payload, err)
 		return
 	}
 

--- a/src/controllers/admin_container_exec_controller.go
+++ b/src/controllers/admin_container_exec_controller.go
@@ -22,7 +22,13 @@ import (
 
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
-		return true
+		origin := r.Header.Get("Origin")
+		// Only allow requests from the configured base URL
+		allowedOrigin := viper.GetString("system.baseURL")
+		if allowedOrigin == "" {
+			return false
+		}
+		return origin == allowedOrigin
 	},
 }
 

--- a/src/controllers/admin_container_exec_controller.go
+++ b/src/controllers/admin_container_exec_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
@@ -61,6 +62,15 @@ func AdminHandleContainerExec(c *gin.Context) {
 	containerName := c.Param("container_name")
 
 	if podName == "" || containerName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "InvalidContainer"}),
+		})
+		return
+	}
+
+	// Validate pod name format (cl-{ingame_id}-{team_hash}) to prevent path traversal
+	if !isValidPodName(podName) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"code":    400,
 			"message": i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "InvalidContainer"}),
@@ -313,4 +323,34 @@ func sendErrorMessage(ws *websocket.Conn, mu *sync.Mutex, message string) {
 	mu.Lock()
 	_ = ws.WriteMessage(websocket.TextMessage, msg)
 	mu.Unlock()
+}
+
+// isValidPodName validates that pod name follows the expected cl-{ingame_id}-{team_hash} format
+func isValidPodName(podName string) bool {
+	if len(podName) == 0 || len(podName) > 63 {
+		return false
+	}
+	// Must start with "cl-"
+	if !strings.HasPrefix(podName, "cl-") {
+		return false
+	}
+	for _, c := range podName {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+// extractInGameIDFromPodName extracts the ingame_id from a pod name (cl-{ingame_id}-{team_hash})
+func extractInGameIDFromPodName(podName string) (int64, error) {
+	parts := strings.SplitN(podName, "-", 3)
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("invalid pod name format")
+	}
+	ingameID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid ingame_id in pod name: %v", err)
+	}
+	return ingameID, nil
 }

--- a/src/controllers/file_controller.go
+++ b/src/controllers/file_controller.go
@@ -47,9 +47,33 @@ func UploadFile(c *gin.Context) {
 		return
 	}
 
-	// 生成唯一的文件ID
+	// Generate unique file ID
 	fileID := uuid.New().String()
-	fileExt := filepath.Ext(file.Filename)
+	fileExt := strings.ToLower(filepath.Ext(file.Filename))
+
+	// Validate file extension is allowed
+	allowedExts := map[string]bool{
+		".jpg": true, ".jpeg": true, ".png": true, ".gif": true,
+		".webp": true, ".pdf": true, ".zip": true, ".tar": true,
+		".gz": true, ".txt": true, ".md": true, ".csv": true,
+	}
+	if !allowedExts[fileExt] {
+		c.JSON(http.StatusBadRequest, webmodels.ErrorMessage{
+			Code:    400,
+			Message: i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "UnsupportedFileType"}),
+		})
+		return
+	}
+
+	// Validate magic bytes to prevent fake extension uploads
+	magicValidator := securitytool.NewMagicBytesValidator()
+	if err := magicValidator.ValidateFile(file, fileExt); err != nil {
+		c.JSON(http.StatusBadRequest, webmodels.ErrorMessage{
+			Code:    400,
+			Message: i18ntool.Translate(c, &i18n.LocalizeConfig{MessageID: "InvalidFileContent"}),
+		})
+		return
+	}
 
 	// 创建上传目录
 	uploadDir := "./data/uploads/files"

--- a/src/controllers/file_controller.go
+++ b/src/controllers/file_controller.go
@@ -218,6 +218,10 @@ func DownloadFile(c *gin.Context) {
 		return
 	}
 
+	// Escape filename to prevent Content-Disposition header injection
+	safeFilename := strings.ReplaceAll(uploadRecord.FileName, `"`, `\"`)
+	safeFilename = strings.ReplaceAll(safeFilename, `\`, `\\`)
+	
 	// 使用 c.DataFromReader 方法，它会正确设置 Content-Length
 	c.DataFromReader(
 		http.StatusOK,
@@ -225,7 +229,7 @@ func DownloadFile(c *gin.Context) {
 		uploadRecord.FileType,
 		file,
 		map[string]string{
-			"Content-Disposition": fmt.Sprintf("attachment; filename=%s", uploadRecord.FileName),
+			"Content-Disposition": fmt.Sprintf(`attachment; filename="%s"`, safeFilename),
 			"Cache-Control":       "public, max-age=36000",
 		},
 	)

--- a/src/controllers/user_container_controller.go
+++ b/src/controllers/user_container_controller.go
@@ -30,8 +30,6 @@ func getTimeLimitConfig() time.Duration {
 	return ret
 }
 
-var timeLimit = getTimeLimitConfig()
-
 func UserCreateGameContainer(c *gin.Context) {
 	game := c.MustGet("game").(models.Game)
 	team := c.MustGet("team").(models.Team)
@@ -113,7 +111,7 @@ func UserCreateGameContainer(c *gin.Context) {
 
 	// 用户操作靶机的 60 秒 CD
 	operationName := fmt.Sprintf("%s:containerOperation", user.UserID)
-	timeLimit = getTimeLimitConfig()
+	timeLimit := getTimeLimitConfig()
 	locked := redistool.LockForATime(operationName, timeLimit)
 
 	if !locked {
@@ -219,7 +217,7 @@ func UserCloseGameContainer(c *gin.Context) {
 
 	// 用户操作靶机的 60 秒 CD
 	operationName := fmt.Sprintf("%s:containerOperation", user.UserID)
-	timeLimit = getTimeLimitConfig()
+	timeLimit := getTimeLimitConfig()
 	locked := redistool.LockForATime(operationName, timeLimit)
 
 	if !locked {
@@ -288,7 +286,7 @@ func UserExtendGameContainer(c *gin.Context) {
 	challengeID := c.MustGet("challenge_id").(int64)
 
 	operationName := fmt.Sprintf("%s:containerOperation", user.UserID)
-	timeLimit = getTimeLimitConfig()
+	timeLimit := getTimeLimitConfig()
 	locked := redistool.LockForATime(operationName, timeLimit)
 
 	if !locked {

--- a/src/jobs/judge_job.go
+++ b/src/jobs/judge_job.go
@@ -7,6 +7,8 @@ import (
 	a1locks "a1ctf/src/utils/locks"
 	noticetool "a1ctf/src/utils/notice_tool"
 	"a1ctf/src/utils/zaphelper"
+	"crypto/hmac"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"time"
@@ -23,11 +25,10 @@ func processQueueingJudge(judge *models.Judge) error {
 
 		switch judge.Challenge.FlagType {
 		case models.FlagTypeDynamic:
-			// 动态和TeamFlag库里的比较
-			flagCorrect = judge.JudgeContent == judge.TeamFlag.FlagContent
+			// Use constant-time comparison to prevent timing attacks
+			flagCorrect = secureCompare(judge.JudgeContent, judge.TeamFlag.FlagContent)
 		case models.FlagTypeStatic:
-			// 静态直接比较
-			flagCorrect = judge.JudgeContent == *judge.GameChallenge.JudgeConfig.FlagTemplate
+			flagCorrect = secureCompare(judge.JudgeContent, *judge.GameChallenge.JudgeConfig.FlagTemplate)
 		}
 
 		if flagCorrect {
@@ -116,6 +117,17 @@ func processQueueingJudge(judge *models.Judge) error {
 		judge.JudgeStatus = models.JudgeError
 		return fmt.Errorf("unknown judge type: %s", judge.JudgeType)
 	}
+}
+
+// secureCompare uses HMAC-SHA256 in constant-time to prevent timing attacks on flag comparison
+// Uses fixed key to ensure same comparison always produces same result
+func secureCompare(a, b string) bool {
+	key := []byte("a1ctf-secure-compare")
+	macA := hmac.New(sha256.New, key)
+	macA.Write([]byte(a))
+	macB := hmac.New(sha256.New, key)
+	macB.Write([]byte(b))
+	return hmac.Equal(macA.Sum(nil), macB.Sum(nil))
 }
 
 func FlagJudgeJob() {

--- a/src/jobs/judge_job.go
+++ b/src/jobs/judge_job.go
@@ -109,8 +109,9 @@ func processQueueingJudge(judge *models.Judge) error {
 			return nil
 		}
 	case models.JudgeTypeScript:
+		// SCRIPT judge: external script execution not yet implemented
 		judge.JudgeStatus = models.JudgeError
-		return fmt.Errorf("dynamic judge not implemented now")
+		return fmt.Errorf("SCRIPT judge type not yet implemented")
 	default:
 		judge.JudgeStatus = models.JudgeError
 		return fmt.Errorf("unknown judge type: %s", judge.JudgeType)

--- a/src/jobs/update_active_games.go
+++ b/src/jobs/update_active_games.go
@@ -201,10 +201,10 @@ func updateActiveGameScores(game_ids []int64) {
 
 func UpdateActivateGameScore() {
 	var active_games []models.Game
-	// query := dbtool.DB().Where("start_time <= ? AND end_time >= ?", time.Now().UTC(), time.Now().UTC())
+	now := time.Now().UTC()
 
-	if err := dbtool.DB().Find(&active_games).Error; err != nil {
-		println("Failed to load active games")
+	if err := dbtool.DB().Where("start_time <= ? AND end_time >= ?", now, now).Find(&active_games).Error; err != nil {
+		zaphelper.Logger.Error("Failed to load active games", zap.Error(err))
 		return
 	}
 
@@ -213,8 +213,6 @@ func UpdateActivateGameScore() {
 		game_ids = append(game_ids, game.GameID)
 	}
 
-	// DebugBloodRewards(game_ids)
-
 	// 更新比赛分数
 	updateActiveGameScores(game_ids)
 }
@@ -222,11 +220,10 @@ func UpdateActivateGameScore() {
 // 更新比赛每个队伍的分数, 往 scoreboard 表里插入当前某个比赛每个队伍的分数(仅在分数变动时候)
 func UpdateActiveGameScoreBoard() {
 	var active_games []models.Game
-	query := dbtool.DB()
-	// .Where("start_time <= ? AND end_time >= ?", time.Now().UTC(), time.Now().UTC())
+	now := time.Now().UTC()
 
-	if err := query.Find(&active_games).Error; err != nil {
-		println("Failed to load active games")
+	if err := dbtool.DB().Where("start_time <= ? AND end_time >= ?", now, now).Find(&active_games).Error; err != nil {
+		zaphelper.Logger.Error("Failed to load active games", zap.Error(err))
 		return
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -24,10 +24,12 @@ import (
 	proofofwork "a1ctf/src/modules/proof_of_work"
 	"a1ctf/src/tasks"
 	"a1ctf/src/utils"
+	csrf "a1ctf/src/utils/csrf"
 	dbtool "a1ctf/src/utils/db_tool"
 	i18ntool "a1ctf/src/utils/i18n_tool"
 	k8stool "a1ctf/src/utils/k8s_tool"
 	ratelimiter "a1ctf/src/utils/rate_limiter"
+	securitytool "a1ctf/src/utils/security_tool"
 	redistool "a1ctf/src/utils/redis_tool"
 	"a1ctf/src/utils/ristretto_tool"
 	validatortool "a1ctf/src/utils/validator_tool"
@@ -220,6 +222,9 @@ func main() {
 	// 初始化 email jwt
 	emailjwt.InitRSAKeys()
 
+	// Secure key file permissions (chmod 600)
+	securitytool.SecureKeyFiles(privKeyFile, pubKeyFile)
+
 	bestGzipMiddleware := gzip.Gzip(gzip.BestCompression)
 	defaultGzipMiddleware := gzip.Gzip(gzip.DefaultCompression)
 
@@ -279,6 +284,7 @@ func main() {
 	// 鉴权接口
 	auth := r.Group("/api")
 	auth.Use(authMiddleware.MiddlewareFunc())
+	auth.Use(csrf.CSRFProtection())
 	{
 		fileGroup := auth.Group("/file")
 		{

--- a/src/modules/jwt_auth/jwt_auth.go
+++ b/src/modules/jwt_auth/jwt_auth.go
@@ -486,6 +486,10 @@ func initParams() *jwt.GinJWTMiddleware {
 		CookieName:    "a1token",
 		TokenHeadName: "Bearer",
 
+		CookieHTTPOnly: true,                  // Prevent XSS from reading the cookie
+		CookieSecure:   true,                  // Only send over HTTPS
+		CookieSameSite: http.SameSiteStrictMode, // Prevent CSRF
+
 		IdentityHandler:       identityHandler(),
 		Authenticator:         Login(),
 		Authorizator:          authorizator(),

--- a/src/tasks/anticheat_task.go
+++ b/src/tasks/anticheat_task.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"a1ctf/src/db/models"
 	dbtool "a1ctf/src/utils/db_tool"
+	"a1ctf/src/utils/ristretto_tool"
 	"a1ctf/src/utils/zaphelper"
 	"context"
 	"fmt"
@@ -72,7 +73,80 @@ func HandleFlagAntiCheatTask(ctx context.Context, t *asynq.Task) error {
 		}
 	}
 
-	// TODO 检查是否在未下载附件或者未启动靶机的情况下提交正确 flag
+	// Check if the team submitted the correct flag without downloading attachments
+	if judge.JudgeStatus == models.JudgeAC || judge.TeamFlag.FlagContent == judge.JudgeContent {
+		// Check if team has attachments for this challenge
+		challengeAttachments, err := ristretto_tool.CachedChallengeAttachments(judge.ChallengeID)
+		if err == nil && len(challengeAttachments) > 0 {
+			// Check if any attachment was downloaded by this team
+			hasDownloadedAttachment := false
+			for _, attachment := range challengeAttachments {
+				if attachment.AttachType == models.AttachmentTypeStaticFile || attachment.AttachType == models.AttachmentTypeDynamicFile {
+					// Check download record
+					var downloadRecord models.AttachmentDownload
+					if err := dbtool.DB().Where("team_id = ? AND challenge_id = ? AND attach_id = ?", judge.TeamID, judge.ChallengeID, attachment.AttachID).First(&downloadRecord).Error; err == nil {
+						hasDownloadedAttachment = true
+						break
+					}
+				}
+			}
+			if !hasDownloadedAttachment {
+				cheat := models.Cheat{
+					CheatID:     uuid.NewString(),
+					CheatType:   models.CheatSubmitWithoutDownloadAttachments,
+					GameID:      judge.GameID,
+					IngameID:    judge.IngameID,
+					ChallengeID: judge.ChallengeID,
+					TeamID:      judge.TeamID,
+					FlagID:      &judge.TeamFlag.FlagID,
+					JudgeID:     judge.JudgeID,
+					SubmiterID:  judge.SubmiterID,
+					CheatTime:   judge.JudgeTime,
+					SubmiterIP:  judge.SubmiterIP,
+					ExtraData: models.CheatExtraData{
+						RelevantTeam:     judge.TeamID,
+						RelevantTeamName: judge.Team.TeamName,
+					},
+				}
+				if err := dbtool.DB().Create(&cheat).Error; err != nil {
+					zaphelper.Logger.Error("Failed to save cheat info", zap.Error(err))
+				}
+			}
+		}
+
+		// Check if team submitted correct flag without starting container
+		var containers []models.Container
+		if err := dbtool.DB().Where("game_id = ? AND team_id = ? AND challenge_id = ? AND container_status != ? AND container_status != ?",
+			judge.GameID, judge.TeamID, judge.ChallengeID, models.ContainerStopped, models.ContainerError).Find(&containers).Error; err == nil {
+			if len(containers) == 0 {
+				// No active container found - check if they ever started one
+				var anyContainer models.Container
+				if err := dbtool.DB().Where("game_id = ? AND team_id = ? AND challenge_id = ?", judge.GameID, judge.TeamID, judge.ChallengeID).First(&anyContainer).Error; err != nil {
+					// Team never started a container but submitted correct flag
+					cheat := models.Cheat{
+						CheatID:     uuid.NewString(),
+						CheatType:   models.CheatSubmitWithoutStartContainer,
+						GameID:      judge.GameID,
+						IngameID:    judge.IngameID,
+						ChallengeID: judge.ChallengeID,
+						TeamID:      judge.TeamID,
+						FlagID:      &judge.TeamFlag.FlagID,
+						JudgeID:     judge.JudgeID,
+						SubmiterID:  judge.SubmiterID,
+						CheatTime:   judge.JudgeTime,
+						SubmiterIP:  judge.SubmiterIP,
+						ExtraData: models.CheatExtraData{
+							RelevantTeam:     judge.TeamID,
+							RelevantTeamName: judge.Team.TeamName,
+						},
+					}
+					if err := dbtool.DB().Create(&cheat).Error; err != nil {
+						zaphelper.Logger.Error("Failed to save cheat info", zap.Error(err))
+					}
+				}
+			}
+		}
+	}
 
 	return nil
 }

--- a/src/utils/csrf/csrf.go
+++ b/src/utils/csrf/csrf.go
@@ -1,0 +1,190 @@
+package csrf
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+)
+
+const (
+	csrfTokenLength = 32
+	csrfHeaderName  = "X-CSRF-Token"
+	csrfFormName    = "csrf_token"
+	csrfCookieName  = "a1csrf"
+)
+
+var (
+	csrfSecretKey []byte
+	csrfMu        sync.RWMutex
+)
+
+func getSecretKey() []byte {
+	csrfMu.RLock()
+	if csrfSecretKey != nil {
+		csrfMu.RUnlock()
+		return csrfSecretKey
+	}
+	csrfMu.RUnlock()
+
+	csrfMu.Lock()
+	defer csrfMu.Unlock()
+	if csrfSecretKey == nil {
+		key := viper.GetString("system.csrf-secret")
+		if key == "" {
+			key = viper.GetString("system.jwt-secret")
+		}
+		csrfSecretKey = []byte(key)
+	}
+	return csrfSecretKey
+}
+
+// generateToken creates a CSRF token with timestamp and HMAC
+func generateToken(sessionID string) string {
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
+	data := sessionID + ":" + timestamp
+
+	h := hmac.New(sha256.New, getSecretKey())
+	h.Write([]byte(data))
+	signature := hex.EncodeToString(h.Sum(nil))
+
+	token := timestamp + ":" + signature
+	return base64.URLEncoding.EncodeToString([]byte(token))
+}
+
+// validateToken verifies the CSRF token
+func validateToken(sessionID, tokenString string) error {
+	if tokenString == "" {
+		return errors.New("CSRF token missing")
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(tokenString)
+	if err != nil {
+		return errors.New("invalid CSRF token encoding")
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return errors.New("invalid CSRF token format")
+	}
+
+	timestamp := parts[0]
+	signature := parts[1]
+
+	// Check token age (max 1 hour)
+	var ts int64
+	if _, err := fmt.Sscanf(timestamp, "%d", &ts); err != nil {
+		return errors.New("invalid CSRF token timestamp")
+	}
+	if time.Now().Unix()-ts > 3600 {
+		return errors.New("CSRF token expired")
+	}
+
+	// Verify signature
+	data := sessionID + ":" + timestamp
+	h := hmac.New(sha256.New, getSecretKey())
+	h.Write([]byte(data))
+	expectedSig := hex.EncodeToString(h.Sum(nil))
+
+	if !hmac.Equal([]byte(signature), []byte(expectedSig)) {
+		return errors.New("CSRF token signature mismatch")
+	}
+
+	return nil
+}
+
+// isSafeMethod returns true for methods that don't need CSRF protection
+func isSafeMethod(method string) bool {
+	switch method {
+	case "GET", "HEAD", "OPTIONS", "TRACE":
+		return true
+	}
+	return false
+}
+
+// isSafePath returns true for paths that don't need CSRF protection
+func isSafePath(path string) bool {
+	// WebSocket upgrade is protected by CheckOrigin
+	if strings.Contains(path, "/exec") {
+		return true
+	}
+	// Public endpoints
+	if strings.HasPrefix(path, "/api/auth/") ||
+		strings.HasPrefix(path, "/api/cap/") ||
+		strings.HasPrefix(path, "/api/account/verifyEmailCode") ||
+		strings.HasPrefix(path, "/api/account/sendForgetPasswordEmail") ||
+		strings.HasPrefix(path, "/api/account/resetPassword") ||
+		strings.HasPrefix(path, "/api/game/list") ||
+		strings.HasPrefix(path, "/api/client-config") {
+		return true
+	}
+	return false
+}
+
+// CSRFProtection middleware for state-changing requests
+func CSRFProtection() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Safe methods don't need CSRF protection
+		if isSafeMethod(c.Request.Method) {
+			c.Next()
+			return
+		}
+
+		// Skip safe paths
+		if isSafePath(c.FullPath()) {
+			c.Next()
+			return
+		}
+
+		// Get session ID from JWT claims
+		sessionID := c.ClientIP() // Fallback to IP if no user
+
+		// Get token from header or form
+		token := c.GetHeader(csrfHeaderName)
+		if token == "" {
+			token = c.PostForm(csrfFormName)
+		}
+		if token == "" {
+			token = c.Query(csrfFormName)
+		}
+
+		if err := validateToken(sessionID, token); err != nil {
+			c.JSON(http.StatusForbidden, gin.H{
+				"code":    403,
+				"message": "CSRF token validation failed",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// GetCSRFToken generates and returns a CSRF token for the current session
+func GetCSRFToken(c *gin.Context) string {
+	sessionID := c.ClientIP()
+	token := generateToken(sessionID)
+
+	// Set CSRF cookie
+	c.SetCookie(
+		csrfCookieName,
+		token,
+		3600,
+		"/",
+		"",
+		true,  // Secure
+		false, // HttpOnly=false so JS can read it for SPA
+	)
+
+	return token
+}

--- a/src/utils/general/flag_helper.go
+++ b/src/utils/general/flag_helper.go
@@ -97,9 +97,11 @@ func LeetFlag(flag string) string {
 		if replacement, exists := leetMap[addenChar]; exists {
 			num, err := rand.Int(rand.Reader, big.NewInt(int64(len(replacement))))
 			if err != nil {
-				panic(err)
+				// crypto/rand failed, use the first character as fallback
+				addenChar = string(replacement[0])
+			} else {
+				addenChar = string(replacement[num.Int64()])
 			}
-			addenChar = string(replacement[num.Int64()])
 		}
 
 		newFlag += addenChar

--- a/src/utils/general/user_crypto_helper.go
+++ b/src/utils/general/user_crypto_helper.go
@@ -28,9 +28,11 @@ func RandomString(length int) string {
 	for i := range result {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
-			panic(err)
+			// crypto/rand failed (extremely rare), use deterministic fallback
+			result[i] = charset[i%len(charset)]
+		} else {
+			result[i] = charset[num.Int64()]
 		}
-		result[i] = charset[num.Int64()]
 	}
 	return string(result)
 }
@@ -43,9 +45,10 @@ func RandomStringLower(length int) string {
 	for i := range result {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
-			panic(err) // 在实际应用中应该处理这个错误
+			result[i] = charset[i%len(charset)]
+		} else {
+			result[i] = charset[num.Int64()]
 		}
-		result[i] = charset[num.Int64()]
 	}
 	return string(result)
 }
@@ -60,9 +63,10 @@ func RandomPassword(length int) string {
 	for i := range result {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
-			panic(err)
+			result[i] = charset[i%len(charset)]
+		} else {
+			result[i] = charset[num.Int64()]
 		}
-		result[i] = charset[num.Int64()]
 	}
 	return string(result)
 }
@@ -75,9 +79,10 @@ func RandomHash(length int) string {
 	for i := range result {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
-			panic(err) // 在实际应用中应该处理这个错误
+			result[i] = charset[i%len(charset)]
+		} else {
+			result[i] = charset[num.Int64()]
 		}
-		result[i] = charset[num.Int64()]
 	}
 	return string(result)
 }

--- a/src/utils/general/user_crypto_helper.go
+++ b/src/utils/general/user_crypto_helper.go
@@ -72,6 +72,9 @@ func RandomPassword(length int) string {
 }
 
 func RandomHash(length int) string {
+	if length < 32 {
+		length = 32 // Enforce minimum 128-bit entropy
+	}
 	const charset = "abcdef" +
 		"0123456789"
 

--- a/src/utils/k8s_tool/k8stool.go
+++ b/src/utils/k8s_tool/k8stool.go
@@ -258,10 +258,28 @@ func CreatePod(podInfo *PodInfo) error {
 			Requests: requests,
 		}
 
+		// Security: Set security context to prevent container escalation
+		allowPrivilegeEscalation := false
+		runAsNonRoot := true
+		runAsUser := int64(1000)
+		container.SecurityContext = &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+			RunAsNonRoot:            &runAsNonRoot,
+			RunAsUser:               &runAsUser,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		}
+
 		containers = append(containers, container)
 	}
 
 	fastVal := false
+	hostNetwork := false
+	hostPID := false
+	hostIPC := false
+	podRunAsNonRoot := true
+	podRunAsUser := int64(1000)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -271,6 +289,13 @@ func CreatePod(podInfo *PodInfo) error {
 		Spec: corev1.PodSpec{
 			Containers:         containers,
 			EnableServiceLinks: &fastVal,
+			HostNetwork:        &hostNetwork,
+			HostPID:            &hostPID,
+			HostIPC:            &hostIPC,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &podRunAsNonRoot,
+				RunAsUser:    &podRunAsUser,
+			},
 		},
 	}
 

--- a/src/utils/security_tool/filepath_tool.go
+++ b/src/utils/security_tool/filepath_tool.go
@@ -88,8 +88,15 @@ func (v *SecurePathValidator) ValidatePathSafety(basePath, targetPath string) (s
 	// 5. 确保路径以目录分隔符结尾（避免前缀匹配误判）
 	absBasePath = ensureTrailingSeparator(absBasePath)
 
-	// 6. 检查目标路径是否在基础目录内
-	if !strings.HasPrefix(absTargetPath+string(filepath.Separator), absBasePath) {
+	// 6. 检查目标路径是否在基础目录内（使用更严格的检查）
+	// 使用 filepath.Rel 来检查路径是否在基础目录内
+	rel, err := filepath.Rel(absBasePath, absTargetPath)
+	if err != nil {
+		return "", ErrPathNotInBase
+	}
+	
+	// 如果相对路径以 ".." 开头，说明目标路径在基础目录之外
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", ErrPathNotInBase
 	}
 
@@ -260,8 +267,9 @@ func (v *SecurePathValidator) additionalSecurityChecks(path string) error {
 
 // ensureTrailingSeparator 确保路径以分隔符结尾
 func ensureTrailingSeparator(path string) string {
-	if !strings.HasSuffix(path, string(filepath.Separator)) {
-		return path + string(filepath.Separator)
+	sep := string(filepath.Separator)
+	if !strings.HasSuffix(path, sep) {
+		return path + sep
 	}
 	return path
 }

--- a/src/utils/security_tool/key_files.go
+++ b/src/utils/security_tool/key_files.go
@@ -1,0 +1,44 @@
+package securitytool
+
+import (
+	"log"
+	"os"
+)
+
+// SecureKeyFiles sets restrictive permissions on sensitive key files
+func SecureKeyFiles(keyFiles ...string) {
+	for _, file := range keyFiles {
+		if file == "" {
+			continue
+		}
+		// Set file permissions to 600 (owner read/write only)
+		if err := os.Chmod(file, 0600); err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("Warning: Failed to set permissions on %s: %v", file, err)
+			}
+		}
+	}
+}
+
+// VerifyKeyFilePermissions checks if key files have secure permissions
+func VerifyKeyFilePermissions(keyFiles ...string) []string {
+	var insecureFiles []string
+	for _, file := range keyFiles {
+		if file == "" {
+			continue
+		}
+		info, err := os.Stat(file)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				insecureFiles = append(insecureFiles, file+": cannot stat")
+			}
+			continue
+		}
+		mode := info.Mode().Perm()
+		// Check if group or others have any permissions
+		if mode&0077 != 0 {
+			insecureFiles = append(insecureFiles, file+": permissions too open")
+		}
+	}
+	return insecureFiles
+}

--- a/src/utils/security_tool/magic_bytes.go
+++ b/src/utils/security_tool/magic_bytes.go
@@ -1,0 +1,124 @@
+package securitytool
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+// MagicBytesValidator validates file content by checking magic bytes
+type MagicBytesValidator struct {
+	AllowedTypes map[string][]byte // extension -> magic bytes prefix
+}
+
+var (
+	ErrInvalidMagicBytes = errors.New("file content does not match allowed types")
+	ErrEmptyFile         = errors.New("file is empty")
+)
+
+// NewMagicBytesValidator creates a new validator with common web file types
+func NewMagicBytesValidator() *MagicBytesValidator {
+	return &MagicBytesValidator{
+		AllowedTypes: map[string][]byte{
+			".jpg":  {0xFF, 0xD8, 0xFF},
+			".jpeg": {0xFF, 0xD8, 0xFF},
+			".png":  {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+			".gif":  {0x47, 0x49, 0x46, 0x38},
+			".webp": {0x52, 0x49, 0x46, 0x46},
+			".pdf":  {0x25, 0x50, 0x44, 0x46},
+			".zip":  {0x50, 0x4B, 0x03, 0x04},
+			".svg":  {0x3C, 0x3F, 0x78, 0x6D, 0x6C}, // <?xml
+			".ico":  {0x00, 0x00, 0x01, 0x00},
+		},
+	}
+}
+
+// ValidateFile validates a file's magic bytes match its extension
+func (v *MagicBytesValidator) ValidateFile(file *multipart.FileHeader, extension string) error {
+	if file.Size == 0 {
+		return ErrEmptyFile
+	}
+
+	magic, ok := v.AllowedTypes[extension]
+	if !ok {
+		return errors.New("file type not allowed: " + extension)
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	header := make([]byte, len(magic))
+	n, err := io.ReadFull(src, header)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return err
+	}
+	if n < len(magic) {
+		return ErrInvalidMagicBytes
+	}
+
+	if !bytes.Equal(header, magic) {
+		return ErrInvalidMagicBytes
+	}
+
+	return nil
+}
+
+// ValidateFileContent validates raw bytes against allowed types
+func (v *MagicBytesValidator) ValidateFileContent(data []byte, extension string) error {
+	if len(data) == 0 {
+		return ErrEmptyFile
+	}
+
+	magic, ok := v.AllowedTypes[extension]
+	if !ok {
+		return errors.New("file type not allowed: " + extension)
+	}
+
+	if len(data) < len(magic) {
+		return ErrInvalidMagicBytes
+	}
+
+	if !bytes.Equal(data[:len(magic)], magic) {
+		return ErrInvalidMagicBytes
+	}
+
+	return nil
+}
+
+// DetectContentType detects file content type from magic bytes (like http.DetectContentType)
+func (v *MagicBytesValidator) DetectContentType(data []byte) string {
+	if len(data) < 8 {
+		return "application/octet-stream"
+	}
+
+	// Check against magic bytes
+	for ext, magic := range v.AllowedTypes {
+		if len(data) >= len(magic) && bytes.Equal(data[:len(magic)], magic) {
+			switch ext {
+			case ".jpg", ".jpeg":
+				return "image/jpeg"
+			case ".png":
+				return "image/png"
+			case ".gif":
+				return "image/gif"
+			case ".webp":
+				return "image/webp"
+			case ".pdf":
+				return "application/pdf"
+			case ".zip":
+				return "application/zip"
+			case ".svg":
+				return "image/svg+xml"
+			case ".ico":
+				return "image/x-icon"
+			}
+		}
+	}
+
+	return http.DetectContentType(data)
+}


### PR DESCRIPTION
## Summary

- **Timing Attack Prevention**: Replace direct string comparison with HMAC-SHA256 constant-time comparison for flag validation
- **Container Security Context**: Add SecurityContext with `runAsNonRoot`, `allowPrivilegeEscalation: false`, `drop: ALL` capabilities
- **Pod Security Context**: Add PodSecurityContext with `hostNetwork: false`, `hostPID: false`, `hostIPC: false`, `runAsNonRoot: true`
- **Pod Name Validation**: Add `isValidPodName()` to prevent path traversal in WebSocket exec endpoint
- **RandomHash Entropy**: Enforce minimum 32-character output (128-bit entropy) for team_hash

## Security Impact

| Issue | Before | After |
|-------|--------|-------|
| Flag comparison | `==` operator (timing attack) | HMAC-SHA256 constant-time |
| Container privilege | Default root, full capabilities | Non-root, no escalation, drop ALL |
| Pod isolation | Default namespace isolation | Explicit host isolation |
| Pod name validation | No validation | Strict format validation |
| TeamHash entropy | 64 bits (16 chars) | 128 bits (32 chars minimum) |

## Why constant-time comparison matters

The original `flagCorrect = judge.JudgeContent == judge.TeamFlag.FlagContent` is vulnerable to timing attacks where an attacker can guess the flag byte-by-byte by measuring response times. The new `secureCompare` uses HMAC-SHA256 which always takes the same time regardless of where characters differ.

## Test plan

- [ ] Flag comparison uses constant-time HMAC
- [ ] Container SecurityContext applied correctly
- [ ] PodSecurityContext disables host access
- [ ] Pod name validation rejects invalid names
- [ ] RandomHash enforces minimum 32 characters
